### PR TITLE
fix(clippy): resolve all remaining clippy warnings

### DIFF
--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -309,7 +309,7 @@ fn extract_result(result: &Value) -> Value {
 
 // ── Commands ──────────────────────────────────────────────────────────────────
 
-fn cmd_init(db_path: &PathBuf, blank: bool, force: bool) -> Result<(), String> {
+fn cmd_init(db_path: &Path, blank: bool, force: bool) -> Result<(), String> {
     let db = open_db(db_path)?;
     let starter = if blank {
         Some(StarterKind::Blank)
@@ -331,7 +331,7 @@ fn cmd_init(db_path: &PathBuf, blank: bool, force: bool) -> Result<(), String> {
     }
 }
 
-fn cmd_show(db_path: &PathBuf, full: bool, as_json: bool) -> Result<(), String> {
+fn cmd_show(db_path: &Path, full: bool, as_json: bool) -> Result<(), String> {
     let db = open_db(db_path)?;
     let result =
         handle_tool_call(&db, "get_ontology", Some(json!({}))).map_err(|e| render_error(&e))?;
@@ -384,7 +384,7 @@ fn cmd_show(db_path: &PathBuf, full: bool, as_json: bool) -> Result<(), String> 
 }
 
 fn cmd_define_class(
-    db_path: &PathBuf,
+    db_path: &Path,
     name: &str,
     desc: Option<&str>,
     iri: Option<&str>,
@@ -406,7 +406,7 @@ fn cmd_define_class(
 }
 
 fn cmd_define_relation(
-    db_path: &PathBuf,
+    db_path: &Path,
     name: &str,
     from: &str,
     to: &str,
@@ -430,7 +430,7 @@ fn cmd_define_relation(
 }
 
 fn cmd_add_property(
-    db_path: &PathBuf,
+    db_path: &Path,
     owner_prop: &str,
     prop_type: &str,
     required: bool,
@@ -464,7 +464,7 @@ fn cmd_add_property(
     Ok(())
 }
 
-fn cmd_add_alias(db_path: &PathBuf, alias: &str, kind: &str, target: &str) -> Result<(), String> {
+fn cmd_add_alias(db_path: &Path, alias: &str, kind: &str, target: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let params = json!({"alias_name": alias, "target": target, "kind": kind});
     let result = handle_tool_call(&db, "add_alias", Some(params)).map_err(|e| render_error(&e))?;
@@ -478,7 +478,7 @@ fn cmd_add_alias(db_path: &PathBuf, alias: &str, kind: &str, target: &str) -> Re
     Ok(())
 }
 
-fn cmd_add_subclass(db_path: &PathBuf, child: &str, parent: &str) -> Result<(), String> {
+fn cmd_add_subclass(db_path: &Path, child: &str, parent: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let params = json!({"child": child, "parent": parent});
     let result =
@@ -491,7 +491,7 @@ fn cmd_add_subclass(db_path: &PathBuf, child: &str, parent: &str) -> Result<(), 
     Ok(())
 }
 
-fn cmd_add_subproperty(db_path: &PathBuf, child: &str, parent: &str) -> Result<(), String> {
+fn cmd_add_subproperty(db_path: &Path, child: &str, parent: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let params = json!({"child": child, "parent": parent});
     let result =
@@ -504,7 +504,7 @@ fn cmd_add_subproperty(db_path: &PathBuf, child: &str, parent: &str) -> Result<(
     Ok(())
 }
 
-fn cmd_validate(db_path: &PathBuf, ontology_only: bool) -> Result<(), String> {
+fn cmd_validate(db_path: &Path, ontology_only: bool) -> Result<(), String> {
     let db = open_db(db_path)?;
     let scope = if ontology_only {
         "ontology"
@@ -533,7 +533,7 @@ fn cmd_validate(db_path: &PathBuf, ontology_only: bool) -> Result<(), String> {
     Err("Validation failed".to_string())
 }
 
-fn cmd_resolve(db_path: &PathBuf, name: &str, kind: &str) -> Result<(), String> {
+fn cmd_resolve(db_path: &Path, name: &str, kind: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let params = json!({"name": name, "kind": kind});
     let result =
@@ -550,7 +550,7 @@ fn cmd_resolve(db_path: &PathBuf, name: &str, kind: &str) -> Result<(), String> 
     Ok(())
 }
 
-fn cmd_create_entity(db_path: &PathBuf, label: &str, props_json: &str) -> Result<(), String> {
+fn cmd_create_entity(db_path: &Path, label: &str, props_json: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let properties: Value = serde_json::from_str(props_json)
         .map_err(|e| format!("Error: invalid JSON for --props: {e}"))?;
@@ -568,7 +568,7 @@ fn cmd_create_entity(db_path: &PathBuf, label: &str, props_json: &str) -> Result
 }
 
 fn cmd_create_relationship(
-    db_path: &PathBuf,
+    db_path: &Path,
     from: &str,
     rel_type: &str,
     to: &str,
@@ -586,7 +586,7 @@ fn cmd_create_relationship(
     Ok(())
 }
 
-fn cmd_explain(db_path: &PathBuf, name: &str, kind: &str) -> Result<(), String> {
+fn cmd_explain(db_path: &Path, name: &str, kind: &str) -> Result<(), String> {
     let db = open_db(db_path)?;
     let params = json!({"name": name, "kind": kind});
     let result =
@@ -601,9 +601,9 @@ fn cmd_explain(db_path: &PathBuf, name: &str, kind: &str) -> Result<(), String> 
 }
 
 fn cmd_import(
-    db_path: &PathBuf,
-    file_path: &PathBuf,
-    template_path: &PathBuf,
+    db_path: &Path,
+    file_path: &Path,
+    template_path: &Path,
     dry_run: bool,
     skip_errors: bool,
 ) -> Result<(), String> {
@@ -708,11 +708,7 @@ fn cmd_import(
     Ok(())
 }
 
-fn cmd_export_json_ld(
-    db_path: &PathBuf,
-    output: Option<&std::path::Path>,
-    pretty: bool,
-) -> Result<(), String> {
+fn cmd_export_json_ld(db_path: &Path, output: Option<&Path>, pretty: bool) -> Result<(), String> {
     let db = open_db(db_path)?;
     let value = export_json_ld(&db).map_err(|e| format!("Error: {e}"))?;
     let json_str = if pretty {
@@ -727,7 +723,7 @@ fn cmd_export_json_ld(
     Ok(())
 }
 
-fn cmd_stats(db_path: &PathBuf) -> Result<(), String> {
+fn cmd_stats(db_path: &Path) -> Result<(), String> {
     let db = open_db(db_path)?;
     let result =
         handle_tool_call(&db, "start_here", Some(json!({}))).map_err(|e| render_error(&e))?;
@@ -749,8 +745,8 @@ fn cmd_stats(db_path: &PathBuf) -> Result<(), String> {
 }
 
 fn cmd_import_turtle(
-    db_path: &PathBuf,
-    file: &PathBuf,
+    db_path: &Path,
+    file: &Path,
     base_iri: Option<String>,
     strategy: &str,
 ) -> Result<(), String> {

--- a/tests/integration/test_cli_phase3.rs
+++ b/tests/integration/test_cli_phase3.rs
@@ -157,9 +157,8 @@ fn cli_validate_clean() {
     let (_dir, db) = initialized_db();
     let result = call(&db, "validate", json!({"scope": "full_graph"}));
 
-    assert_eq!(
+    assert!(
         result["valid"].as_bool().unwrap_or(false),
-        true,
         "freshly initialized DB should be valid, got: {result}"
     );
     let violations = result["violations"]
@@ -183,9 +182,8 @@ fn cli_resolve_alias() {
         "add_alias",
         json!({"alias_name": "EMPLOYED_BY", "target": "WORKS_FOR", "kind": "relation"}),
     );
-    assert_eq!(
+    assert!(
         alias_result["success"].as_bool().unwrap_or(false),
-        true,
         "add_alias should succeed, got: {alias_result}"
     );
 
@@ -200,9 +198,8 @@ fn cli_resolve_alias() {
         "WORKS_FOR",
         "canonical_name should be 'WORKS_FOR', got: {resolve_result}"
     );
-    assert_eq!(
+    assert!(
         resolve_result["was_alias"].as_bool().unwrap_or(false),
-        true,
         "was_alias should be true when resolving an alias"
     );
 }
@@ -219,9 +216,8 @@ fn cli_add_alias() {
         "add_alias",
         json!({"alias_name": "TEST", "target": "Person", "kind": "class"}),
     );
-    assert_eq!(
+    assert!(
         alias_result["success"].as_bool().unwrap_or(false),
-        true,
         "add_alias TEST → Person should succeed, got: {alias_result}"
     );
 
@@ -236,9 +232,8 @@ fn cli_add_alias() {
         "Person",
         "canonical_name should be 'Person', got: {resolve_result}"
     );
-    assert_eq!(
+    assert!(
         resolve_result["was_alias"].as_bool().unwrap_or(false),
-        true,
         "was_alias should be true for 'TEST', got: {resolve_result}"
     );
 }
@@ -254,9 +249,8 @@ fn cli_create_entity_person() {
         "create_entity",
         json!({"label": "Person", "properties": {"name": "Alice"}}),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true, got: {result}"
     );
     assert!(

--- a/tests/integration/test_mcp_monitoring.rs
+++ b/tests/integration/test_mcp_monitoring.rs
@@ -45,9 +45,8 @@ fn health_on_initialized_db_returns_ok() {
         "sparrow-ontology-mcp",
         "service name should be 'sparrow-ontology-mcp', got: {result}"
     );
-    assert_eq!(
+    assert!(
         result["db_connected"].as_bool().unwrap_or(false),
-        true,
         "db_connected should be true, got: {result}"
     );
     let class_count = result["class_count"]
@@ -76,9 +75,8 @@ fn health_on_empty_db_still_reports_connected() {
         "ok",
         "health status should be 'ok' even on empty db, got: {result}"
     );
-    assert_eq!(
+    assert!(
         result["db_connected"].as_bool().unwrap_or(false),
-        true,
         "db_connected should be true even when ontology is not initialized, got: {result}"
     );
     assert_eq!(

--- a/tests/integration/test_mcp_phase2.rs
+++ b/tests/integration/test_mcp_phase2.rs
@@ -169,9 +169,8 @@ fn ac06_add_alias_then_resolve_name() {
         "add_alias",
         json!({"alias_name": "EMPLOYED_BY", "target": "WORKS_FOR", "kind": "relation"}),
     );
-    assert_eq!(
+    assert!(
         alias_result["success"].as_bool().unwrap_or(false),
-        true,
         "add_alias should succeed, got: {alias_result}"
     );
 
@@ -186,9 +185,8 @@ fn ac06_add_alias_then_resolve_name() {
         "WORKS_FOR",
         "canonical_name should be 'WORKS_FOR', got: {resolve_result}"
     );
-    assert_eq!(
+    assert!(
         resolve_result["was_alias"].as_bool().unwrap_or(false),
-        true,
         "was_alias should be true"
     );
 }
@@ -203,9 +201,8 @@ fn ac07_create_entity_person() {
         "create_entity",
         json!({"class_name": "Person", "properties": {"name": "Alice"}}),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true, got: {result}"
     );
     assert!(
@@ -230,9 +227,8 @@ fn ac08_create_entity_via_alias() {
         "create_entity",
         json!({"class_name": "Human", "properties": {"name": "Bob"}}),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true for alias 'Human', got: {result}"
     );
     assert_eq!(
@@ -262,9 +258,8 @@ fn ac09_create_entity_preserve_source_terms() {
             "preserve_source_terms": true
         }),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true, got: {result}"
     );
     // source_label should be "Human" (the alias used)
@@ -327,9 +322,8 @@ fn ac11_create_relationship_valid() {
         "create_relationship",
         json!({"from_id": alice_id, "relation_name": "WORKS_FOR", "to_id": acme_id}),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true, got: {result}"
     );
 }
@@ -370,9 +364,8 @@ fn ac12_create_relationship_via_alias() {
         "create_relationship",
         json!({"from_id": alice_id, "relation_name": "EMPLOYED_BY", "to_id": acme_id}),
     );
-    assert_eq!(
+    assert!(
         result["created"].as_bool().unwrap_or(false),
-        true,
         "created should be true via alias 'EMPLOYED_BY', got: {result}"
     );
 }
@@ -440,9 +433,8 @@ fn ac14_update_entity_validates() {
         "update_entity",
         json!({"node_id": node_id, "properties": {"name": "Alicia"}}),
     );
-    assert_eq!(
+    assert!(
         update_result["updated"].as_bool().unwrap_or(false),
-        true,
         "updated should be true for valid property, got: {update_result}"
     );
 
@@ -700,9 +692,8 @@ fn ac20_explain_symbol_relation() {
 fn ac21_validate_clean_graph() {
     let (_dir, db) = initialized_db();
     let result = call(&db, "validate", json!({"scope": "full_graph"}));
-    assert_eq!(
+    assert!(
         result["valid"].as_bool().unwrap_or(false),
-        true,
         "valid should be true for clean initialized graph, got: {result}"
     );
     let violations = result["violations"]
@@ -736,9 +727,8 @@ fn ac22_validate_reports_violations() {
     }
 
     let result = call(&db, "validate", json!({"scope": "full_graph"}));
-    assert_eq!(
-        result["valid"].as_bool().unwrap_or(true),
-        false,
+    assert!(
+        !result["valid"].as_bool().unwrap_or(true),
         "valid should be false when unknown-label nodes exist, got: {result}"
     );
     let violations = result["violations"]
@@ -787,9 +777,8 @@ fn ac23_validate_no_false_positives_with_relationships() {
 
     // Validate — must not produce false-positive violations for "WORKS_FOR" label
     let result = call(&db, "validate", json!({"scope": "full_graph"}));
-    assert_eq!(
+    assert!(
         result["valid"].as_bool().unwrap_or(false),
-        true,
         "validate should be clean after creating typed entities + relationship, got: {result}"
     );
     let violations = result["violations"].as_array().expect("violations array");


### PR DESCRIPTION
## **User description**
## Summary
- Replace 17 `&PathBuf` parameters with `&Path` in CLI main.rs for idiomatic Rust API design
- Replace 19 `assert_eq!(x, true/false)` with `assert!()` / `assert!(!x)` across 3 test files
- `cargo clippy --all-targets -- -D warnings` now passes clean

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — all tests pass
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Resolve remaining lint warnings in the CLI and integration tests**

### What Changed
- Replaced boolean equality checks in integration tests with direct true/false assertions
- Updated CLI helper signatures to accept path references instead of owned path values
- No user-facing behavior changed; this keeps the codebase lint-clean and the tests easier to maintain

### Impact
`✅ Cleaner CI lint runs`
`✅ Fewer style-related test failures`
`✅ Easier maintenance of CLI code`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency across CLI command implementations.

* **Tests**
  * Enhanced test assertions for better reliability and clarity.

These changes are internal improvements with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->