### PR TITLE
feat: instance-data RDF export/import (WS1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "clap",
  "csv",
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb-catalog"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "crc32fast",
  "sparrowdb-common",
@@ -1066,7 +1066,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb-common"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "crc32fast",
  "serde",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb-cypher"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "sparrowdb-catalog",
  "sparrowdb-common",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb-execution"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "bincode",
  "rayon",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "sparrowdb-storage"
 version = "0.1.27"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
+source = "git+https://github.com/ryaker/SparrowDB?rev=903ea739ea7a31157b25948656e222a3b82a79e1#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "bincode",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,12 +1036,13 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a942ddb404d112bde8d27fd3f695e7b0a09744b09e31e73a0b705c669c988669"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
  "clap",
+ "csv",
  "rand",
+ "rand_chacha",
  "serde",
  "serde_json",
  "sparrowdb-catalog",
@@ -1054,9 +1055,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-catalog"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adeec1b618be8542dc53370109efcd441440b8abe19072333123cea8941c64c6"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
  "crc32fast",
  "sparrowdb-common",
@@ -1065,9 +1065,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-common"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d477e15dc15ee49e1fc3bbe33fd627903f660ffb234d8e0c885de7794655d1"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
  "crc32fast",
  "serde",
@@ -1075,9 +1074,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-cypher"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ca345cfb5abf026c8cd6fa6e48dbc2c3c552b7d473bc5d0e14914120f17ec5"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
  "sparrowdb-catalog",
  "sparrowdb-common",
@@ -1085,9 +1083,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-execution"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf00afe3fa5a7f8998f03261ff2d151493e6bc3e015e2a1e510483ee618415d6"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
  "bincode",
  "rayon",
@@ -1155,15 +1152,16 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-storage"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c4e8df519e75585b46c134a8d37db2c3720d616b3d1f1245d3f0d524a736b8"
+version = "0.1.25"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
 dependencies = [
+ "bincode",
  "chacha20poly1305",
  "crc32c",
  "crc32fast",
  "memmap2",
  "rand",
+ "serde",
  "sparrowdb-common",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,8 +1036,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "clap",
  "csv",
@@ -1055,8 +1055,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-catalog"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "crc32fast",
  "sparrowdb-common",
@@ -1065,8 +1065,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-common"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "crc32fast",
  "serde",
@@ -1074,8 +1074,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-cypher"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "sparrowdb-catalog",
  "sparrowdb-common",
@@ -1083,8 +1083,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-execution"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "bincode",
  "rayon",
@@ -1152,8 +1152,8 @@ dependencies = [
 
 [[package]]
 name = "sparrowdb-storage"
-version = "0.1.25"
-source = "git+https://github.com/ryaker/SparrowDB?branch=main#712ace45a737222b36b311408f1e0c84b8fd2d3e"
+version = "0.1.27"
+source = "git+https://github.com/ryaker/SparrowDB?branch=main#903ea739ea7a31157b25948656e222a3b82a79e1"
 dependencies = [
  "bincode",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,20 @@ resolver = "2"
 # builds anywhere, including CI, and Cargo.lock pins the exact rev that was
 # tested.
 #
+# Pinned to an explicit `rev`, not `branch = "main"`: SparrowDB's main moves
+# fast (engine-semantics changes included), so a branch reference is not a
+# stable input — any `cargo update` would silently float to whatever main is
+# at that moment. Bump this rev deliberately, verify against it, then update
+# Cargo.lock in the same commit.
+#
 # NOTE FOR RELEASE: crates.io forbids git dependencies in *published* crates.
-# SparrowOntology is not publishing yet, so this is fine for development, but
-# this block MUST be replaced with a plain `sparrowdb = "0.1.23"` version
-# requirement before any sparrowdb-ontology-* crate is published.
+# SparrowOntology is not publishing yet, but 0.1.23 (the last version this
+# comment used to suggest) predates the duplicate-edge and dangling-edge
+# fixes this pin exists for — this block must be replaced with a plain
+# version requirement of >= whatever release actually contains PR #512
+# and the duplicate-edge fix, once one is cut.
 [patch.crates-io]
-sparrowdb           = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
-sparrowdb-execution = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
-sparrowdb-common    = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
-sparrowdb-storage   = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
+sparrowdb           = { git = "https://github.com/ryaker/SparrowDB", rev = "903ea739ea7a31157b25948656e222a3b82a79e1" }
+sparrowdb-execution = { git = "https://github.com/ryaker/SparrowDB", rev = "903ea739ea7a31157b25948656e222a3b82a79e1" }
+sparrowdb-common    = { git = "https://github.com/ryaker/SparrowDB", rev = "903ea739ea7a31157b25948656e222a3b82a79e1" }
+sparrowdb-storage   = { git = "https://github.com/ryaker/SparrowDB", rev = "903ea739ea7a31157b25948656e222a3b82a79e1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,24 @@
 members = ["crates/sparrowdb-ontology-core", "crates/sparrowdb-ontology-mcp", "crates/sparrowdb-ontology-cli"]
 resolver = "2"
 
-
+# ── SparrowDB engine override ────────────────────────────────────────────────
+#
+# WS1 (instance-data RDF export) requires engine fixes that are on SparrowDB
+# `main` but are NOT in any published release. In particular the duplicate-edge
+# bug present through crates.io 0.1.22 would make `export_data_turtle` emit
+# duplicate RDF triples for a single relationship.
+#
+# The previous override pointed at an absolute local path
+# (/Users/ryaker/Dev/SparrowDB), which only builds on one machine. A git source
+# builds anywhere, including CI, and Cargo.lock pins the exact rev that was
+# tested.
+#
+# NOTE FOR RELEASE: crates.io forbids git dependencies in *published* crates.
+# SparrowOntology is not publishing yet, so this is fine for development, but
+# this block MUST be replaced with a plain `sparrowdb = "0.1.23"` version
+# requirement before any sparrowdb-ontology-* crate is published.
+[patch.crates-io]
+sparrowdb           = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
+sparrowdb-execution = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
+sparrowdb-common    = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }
+sparrowdb-storage   = { git = "https://github.com/ryaker/SparrowDB", branch = "main" }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sparrow-ontology-mcp --db my.db --transport http --port 3456
 
 ---
 
-## MCP Tools (19 total)
+## MCP Tools (22 total)
 
 | Tool | What it does |
 |------|-------------|
@@ -105,6 +105,9 @@ sparrow-ontology-mcp --db my.db --transport http --port 3456
 | `resolve_name` | Resolve an alias to its canonical symbol. |
 | `export_json_ld` | Export the full ontology as a JSON-LD document — owl:Class, owl:ObjectProperty, rdfs:subClassOf, skos:altLabel, and so: extensions. |
 | `import_turtle` | Import classes, relations, subclasses, and aliases from Turtle (.ttl) text. Handles schema.org domainIncludes/rangeIncludes. Unsupported OWL constructs fail gracefully with warnings. |
+| `export_data_turtle` | Export the instance **data** (entities + relationships) as Turtle, with XSD datatypes derived from the ontology. Reports anything it could not represent. |
+| `export_data_json_ld` | The same data graph as JSON-LD 1.1, with an `@context` derived from the ontology. |
+| `import_data_turtle` | Import instance data through the validated write path. Every skip is reported with its subject IRI and an actionable reason. |
 
 ---
 
@@ -347,7 +350,7 @@ SparrowDB  (embedded Rust graph engine · zero external deps)
 git clone https://github.com/ryaker/SparrowOntology
 cd SparrowOntology
 cargo build --workspace
-cargo test --workspace       # 166 tests, all integration, no mocks
+cargo test --workspace       # 211 tests, all integration, no mocks
 ```
 
 Requires Rust 1.75+.

--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -774,6 +774,12 @@ fn cmd_import_turtle(
         "  Skipped (no domain): {}",
         summary.skipped_no_domain_properties.len()
     );
+    if !summary.dropped_property_comments.is_empty() {
+        println!(
+            "  Comments not stored (no add_property API): {}",
+            summary.dropped_property_comments.len()
+        );
+    }
     if !summary.warnings.is_empty() {
         println!("Warnings ({}):", summary.warnings.len());
         for w in &summary.warnings {

--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -770,6 +770,10 @@ fn cmd_import_turtle(
     println!("  Relations:  {}", summary.relations_imported);
     println!("  Subclasses: {}", summary.subclasses_imported);
     println!("  Aliases:    {}", summary.aliases_imported);
+    println!(
+        "  Skipped (no domain): {}",
+        summary.skipped_no_domain_properties.len()
+    );
     if !summary.warnings.is_empty() {
         println!("Warnings ({}):", summary.warnings.len());
         for w in &summary.warnings {

--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -774,12 +774,6 @@ fn cmd_import_turtle(
         "  Skipped (no domain): {}",
         summary.skipped_no_domain_properties.len()
     );
-    if !summary.dropped_property_comments.is_empty() {
-        println!(
-            "  Comments not stored (no add_property API): {}",
-            summary.dropped_property_comments.len()
-        );
-    }
     if !summary.warnings.is_empty() {
         println!("Warnings ({}):", summary.warnings.len());
         for w in &summary.warnings {

--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -6,7 +6,8 @@ use clap::{Parser, Subcommand};
 use serde_json::{json, Value};
 use sparrowdb::GraphDb;
 use sparrowdb_ontology_core::{
-    export_json_ld, import_records, import_turtle, init, DomainRangeStrategy, ImportOptions,
+    export_data_json_ld, export_data_with_report, export_json_ld, import_data_turtle,
+    import_records, import_turtle, init, DomainRangeStrategy, ImportOptions, ImportStrategy,
     ImportTemplate, StarterKind,
 };
 use sparrowdb_ontology_mcp::tools::handle_tool_call;
@@ -202,6 +203,30 @@ enum Commands {
         #[arg(long, default_value = "unconstrained")]
         strategy: String,
     },
+    /// Export instance data (entities and relationships) as RDF
+    ExportData {
+        #[arg(long)]
+        db: PathBuf,
+        /// Output format
+        #[arg(long, default_value = "ttl", value_parser = ["ttl", "jsonld"])]
+        format: String,
+        /// Base IRI that entity IRIs are minted under, e.g. https://example.org/kb
+        #[arg(long)]
+        base: String,
+        /// Write output to this file path (default: stdout)
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+    /// Import instance data from a Turtle (.ttl) file
+    ImportData {
+        /// Path to the Turtle file to import
+        file: PathBuf,
+        #[arg(long)]
+        db: PathBuf,
+        /// 'strict' rejects unknown classes/relations/properties; 'auto-declare' creates them
+        #[arg(long, default_value = "strict", value_parser = ["strict", "auto-declare"])]
+        strategy: String,
+    },
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -274,6 +299,13 @@ fn run(cli: Cli) -> Result<(), String> {
             base_iri,
             strategy,
         } => cmd_import_turtle(&db, &file, base_iri, &strategy),
+        Commands::ExportData {
+            db,
+            format,
+            base,
+            out,
+        } => cmd_export_data(&db, &format, &base, out.as_deref()),
+        Commands::ImportData { file, db, strategy } => cmd_import_data(&db, &file, &strategy),
     }
 }
 
@@ -779,6 +811,116 @@ fn cmd_import_turtle(
         for w in &summary.warnings {
             println!("  - {w}");
         }
+    }
+    Ok(())
+}
+
+// ── Instance-data RDF (WS1) ───────────────────────────────────────────────────
+
+/// Export entities and relationships as RDF.
+///
+/// The graph goes to stdout (or `--out`); the report of anything that could not
+/// be represented goes to stderr, so `--out` stays a clean RDF file and a
+/// stdout pipe stays parseable.
+fn cmd_export_data(
+    db_path: &Path,
+    format: &str,
+    base: &str,
+    out: Option<&Path>,
+) -> Result<(), String> {
+    let db = open_db(db_path)?;
+
+    let (text, report) = match format {
+        "jsonld" => {
+            let doc = export_data_json_ld(&db, base).map_err(|e| format!("Error: {e}"))?;
+            let s = serde_json::to_string_pretty(&doc).map_err(|e| format!("Error: {e}"))?;
+            // Re-run for the report; the export itself is read-only.
+            let (_, report) =
+                export_data_with_report(&db, base).map_err(|e| format!("Error: {e}"))?;
+            (s, report)
+        }
+        _ => export_data_with_report(&db, base).map_err(|e| format!("Error: {e}"))?,
+    };
+
+    match out {
+        Some(path) => {
+            std::fs::write(path, &text)
+                .map_err(|e| format!("Error: cannot write {}: {e}", path.display()))?;
+            eprintln!("Wrote {} ({} bytes)", path.display(), text.len());
+        }
+        None => println!("{text}"),
+    }
+
+    eprintln!("Export complete:");
+    eprintln!("  Entities:      {}", report.entities_exported);
+    eprintln!("  Relationships: {}", report.relationships_exported);
+    eprintln!("  Triples:       {}", report.triples_emitted);
+    if report.orphan_properties > 0 {
+        eprintln!(
+            "  Undeclared columns skipped: {} (declare them with add_property to export them)",
+            report.orphan_properties
+        );
+    }
+    if report.dangling_edges > 0 {
+        eprintln!("  Dangling edges skipped:     {}", report.dangling_edges);
+    }
+    for label in &report.orphan_labels {
+        eprintln!("  Unknown label skipped:      {label}");
+    }
+    for rel in &report.orphan_relation_types {
+        eprintln!("  Unknown relation skipped:   {rel}");
+    }
+    Ok(())
+}
+
+/// Import entities and relationships from Turtle.
+///
+/// Exits nonzero if anything was skipped, so the command is usable as a gate in
+/// a pipeline.
+fn cmd_import_data(db_path: &Path, file: &Path, strategy: &str) -> Result<(), String> {
+    let ttl = std::fs::read_to_string(file)
+        .map_err(|e| format!("Error: cannot read file {}: {e}", file.display()))?;
+    let db = open_db(db_path)?;
+
+    let strategy = match strategy {
+        "auto-declare" => ImportStrategy::AutoDeclare,
+        _ => ImportStrategy::Strict,
+    };
+
+    let report = import_data_turtle(&db, &ttl, strategy).map_err(|e| format!("Error: {e}"))?;
+
+    println!("Import complete:");
+    println!("  Entities imported:      {}", report.entities_imported);
+    println!(
+        "  Relationships imported: {}",
+        report.relationships_imported
+    );
+    if report.classes_declared + report.relations_declared + report.properties_declared > 0 {
+        println!(
+            "  Declared: {} classes, {} relations, {} properties",
+            report.classes_declared, report.relations_declared, report.properties_declared
+        );
+    }
+    if report.blank_nodes_skipped > 0 {
+        println!(
+            "  Blank nodes skipped:    {} (blank-node preservation is out of scope)",
+            report.blank_nodes_skipped
+        );
+    }
+    for w in &report.warnings {
+        println!("  warning: {w}");
+    }
+
+    let skipped = report.entities_skipped + report.relationships_skipped;
+    if skipped > 0 {
+        println!(
+            "  Skipped: {} entities, {} relationships",
+            report.entities_skipped, report.relationships_skipped
+        );
+        for s in &report.skips {
+            println!("    <{}>: {}", s.subject, s.reason);
+        }
+        return Err(format!("{skipped} item(s) were not imported"));
     }
     Ok(())
 }

--- a/crates/sparrowdb-ontology-cli/src/main.rs
+++ b/crates/sparrowdb-ontology-cli/src/main.rs
@@ -856,19 +856,34 @@ fn cmd_export_data(
     eprintln!("  Relationships: {}", report.relationships_exported);
     eprintln!("  Triples:       {}", report.triples_emitted);
     if report.orphan_properties > 0 {
-        eprintln!(
-            "  Undeclared columns skipped: {} (declare them with add_property to export them)",
-            report.orphan_properties
-        );
+        eprintln!("  Undeclared columns skipped: {}", report.orphan_properties);
     }
     if report.dangling_edges > 0 {
         eprintln!("  Dangling edges skipped:     {}", report.dangling_edges);
     }
-    for label in &report.orphan_labels {
-        eprintln!("  Unknown label skipped:      {label}");
+    if !report.orphan_labels.is_empty() {
+        eprintln!(
+            "  Unknown labels skipped:     {}",
+            report.orphan_labels.len()
+        );
     }
-    for rel in &report.orphan_relation_types {
-        eprintln!("  Unknown relation skipped:   {rel}");
+    if !report.orphan_relation_types.is_empty() {
+        eprintln!(
+            "  Unknown relations skipped:  {}",
+            report.orphan_relation_types.len()
+        );
+    }
+    if report.unrepresentable_iris > 0 {
+        eprintln!(
+            "  Unrepresentable IRIs skipped: {}",
+            report.unrepresentable_iris
+        );
+    }
+    if !report.issues.is_empty() {
+        eprintln!("Issues ({}):", report.issues.len());
+        for issue in &report.issues {
+            eprintln!("  <{}>: {}", issue.subject, issue.reason);
+        }
     }
     Ok(())
 }
@@ -912,7 +927,8 @@ fn cmd_import_data(db_path: &Path, file: &Path, strategy: &str) -> Result<(), St
     }
 
     let skipped = report.entities_skipped + report.relationships_skipped;
-    if skipped > 0 {
+    let skipped_total = skipped + report.blank_nodes_skipped;
+    if skipped_total > 0 {
         println!(
             "  Skipped: {} entities, {} relationships",
             report.entities_skipped, report.relationships_skipped
@@ -920,7 +936,7 @@ fn cmd_import_data(db_path: &Path, file: &Path, strategy: &str) -> Result<(), St
         for s in &report.skips {
             println!("    <{}>: {}", s.subject, s.reason);
         }
-        return Err(format!("{skipped} item(s) were not imported"));
+        return Err(format!("{skipped_total} item(s) were not imported"));
     }
     Ok(())
 }

--- a/crates/sparrowdb-ontology-core/Cargo.toml
+++ b/crates/sparrowdb-ontology-core/Cargo.toml
@@ -10,14 +10,14 @@ documentation = "https://docs.rs/sparrowdb-ontology-core"
 
 [dependencies]
 # SparrowDB engine — published to crates.io (SPA-210, v0.1.1)
-sparrowdb = "0.1.8"
+sparrowdb = "0.1.20"
 # Sub-crate deps needed for QueryResult, Value(exec), Error, and Value(storage) types.
 # sparrowdb does not re-export them yet — TODO: simplify in a future sparrowdb release.
 # SPA-208: __SO_ prefix is protected at Cypher layer; we use WriteTx low-level API
 # for seeding (bypasses Cypher-layer reservation check, which is correct behavior).
-sparrowdb-execution = "0.1.8"
-sparrowdb-common = "0.1.8"
-sparrowdb-storage = "0.1.8"
+sparrowdb-execution = "0.1.20"
+sparrowdb-common = "0.1.20"
+sparrowdb-storage = "0.1.20"
 uuid = { version = "1", features = ["v4"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -29,6 +29,10 @@ oxrdf = "0.3"
 tempfile = "3"
 csv = "1"
 serde_json = "1"
+
+[[test]]
+name = "test_rdf_data"
+path = "../../tests/integration/test_rdf_data.rs"
 
 [[test]]
 name = "test_world_model"

--- a/crates/sparrowdb-ontology-core/src/init.rs
+++ b/crates/sparrowdb-ontology-core/src/init.rs
@@ -443,6 +443,7 @@ pub fn add_alias(
 ///
 /// Returns `SoError::DuplicateProperty` if a property with this name is already
 /// declared on the resolved class.
+#[allow(clippy::too_many_arguments)]
 pub fn add_property(
     db: &GraphDb,
     owner: &str,
@@ -451,6 +452,8 @@ pub fn add_property(
     required: bool,
     unique: bool,
     allowed_values: Option<Vec<String>>,
+    description: Option<&str>,
+    source_iri: Option<&str>,
 ) -> Result<OntologyProperty, SoError> {
     // Guard: reserved key prefix
     if prop_name.starts_with("__so_") || prop_name.starts_with("__SO_") {
@@ -498,21 +501,29 @@ pub fn add_property(
         .map(|v| serde_json::to_string(v).unwrap_or_default())
         .unwrap_or_default();
 
+    let mut node_props = vec![
+        ("symbol_id", sv(&symbol_id)),
+        ("name", sv(prop_name)),
+        ("datatype", sv(datatype_label)),
+        ("required", bv(required)),
+        ("unique", bv(unique)),
+        ("enum_values", sv(&enum_json)),
+        ("owner_symbol_id", sv(&class_sym.symbol_id)),
+        ("owner_kind", sv("class")),
+        ("created_at", iv(now)),
+    ];
+    let desc_val;
+    let iri_val;
+    if let Some(d) = description {
+        desc_val = sv(d);
+        node_props.push(("description", desc_val));
+    }
+    if let Some(i) = source_iri {
+        iri_val = sv(i);
+        node_props.push(("source_iri", iri_val));
+    }
     let mut tx = db.begin_write()?;
-    let prop_node_id = tx.merge_node(
-        PROPERTY_LABEL,
-        props(&[
-            ("symbol_id", sv(&symbol_id)),
-            ("name", sv(prop_name)),
-            ("datatype", sv(datatype_label)),
-            ("required", bv(required)),
-            ("unique", bv(unique)),
-            ("enum_values", sv(&enum_json)),
-            ("owner_symbol_id", sv(&class_sym.symbol_id)),
-            ("owner_kind", sv("class")),
-            ("created_at", iv(now)),
-        ]),
-    )?;
+    let prop_node_id = tx.merge_node(PROPERTY_LABEL, props(&node_props))?;
     tx.commit()?;
 
     // Create HAS_PROPERTY edge: class → property
@@ -547,6 +558,8 @@ pub fn add_property(
         owner_kind: crate::model::OwnerKind::Class,
         created_at: now,
         owner_name: class_sym.canonical_name,
+        description: description.map(str::to_string),
+        source_iri: source_iri.map(str::to_string),
     })
 }
 

--- a/crates/sparrowdb-ontology-core/src/init.rs
+++ b/crates/sparrowdb-ontology-core/src/init.rs
@@ -512,15 +512,11 @@ pub fn add_property(
         ("owner_kind", sv("class")),
         ("created_at", iv(now)),
     ];
-    let desc_val;
-    let iri_val;
     if let Some(d) = description {
-        desc_val = sv(d);
-        node_props.push(("description", desc_val));
+        node_props.push(("description", sv(d)));
     }
     if let Some(i) = source_iri {
-        iri_val = sv(i);
-        node_props.push(("source_iri", iri_val));
+        node_props.push(("source_iri", sv(i)));
     }
     let mut tx = db.begin_write()?;
     let prop_node_id = tx.merge_node(PROPERTY_LABEL, props(&node_props))?;
@@ -563,7 +559,7 @@ pub fn add_property(
     })
 }
 
-fn parse_property_type_str(s: &str) -> PropertyType {
+pub(crate) fn parse_property_type_str(s: &str) -> PropertyType {
     match s {
         "string" => PropertyType::String,
         "int64" => PropertyType::Int64,

--- a/crates/sparrowdb-ontology-core/src/lib.rs
+++ b/crates/sparrowdb-ontology-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod init;
 pub mod jsonld;
 pub mod model;
 pub mod namespace;
+pub mod rdf_data;
 pub mod resolution;
 pub mod snapshot;
 pub mod turtle_import;
@@ -23,6 +24,10 @@ pub use model::{
     research_notes_classes, research_notes_properties, research_notes_relations, AliasKind,
     OntologyAlias, OntologyClass, OntologyProperty, OntologyRelation, OwnerKind, PropertyType,
     PropertyValue, SymbolStatus,
+};
+pub use rdf_data::{
+    export_data_json_ld, export_data_turtle, export_data_with_report, import_data_turtle,
+    property_type_to_xsd, ExportIssue, ExportReport, ImportReport, ImportSkip, ImportStrategy,
 };
 pub use resolution::{resolve, ResolvedSymbol};
 pub use snapshot::{

--- a/crates/sparrowdb-ontology-core/src/lib.rs
+++ b/crates/sparrowdb-ontology-core/src/lib.rs
@@ -27,7 +27,8 @@ pub use model::{
 };
 pub use rdf_data::{
     export_data_json_ld, export_data_turtle, export_data_with_report, import_data_turtle,
-    property_type_to_xsd, ExportIssue, ExportReport, ImportReport, ImportSkip, ImportStrategy,
+    property_type_to_xsd, property_value_to_store, ExportIssue, ExportReport, ImportReport,
+    ImportSkip, ImportStrategy,
 };
 pub use resolution::{resolve, ResolvedSymbol};
 pub use snapshot::{

--- a/crates/sparrowdb-ontology-core/src/model.rs
+++ b/crates/sparrowdb-ontology-core/src/model.rs
@@ -146,6 +146,10 @@ pub struct OntologyProperty {
     pub created_at: i64,
     /// Owner name — used during seeding to look up owner_symbol_id.
     pub owner_name: String,
+    /// `rdfs:comment` or other description text, if provided at import time.
+    pub description: Option<String>,
+    /// Source IRI of the originating `owl:DatatypeProperty`, if imported from Turtle.
+    pub source_iri: Option<String>,
 }
 
 impl OntologyProperty {
@@ -162,6 +166,8 @@ impl OntologyProperty {
             owner_kind: OwnerKind::Class,
             created_at: now_utc_ms(),
             owner_name: owner.to_string(),
+            description: None,
+            source_iri: None,
         }
     }
 

--- a/crates/sparrowdb-ontology-core/src/namespace.rs
+++ b/crates/sparrowdb-ontology-core/src/namespace.rs
@@ -25,3 +25,11 @@ pub const RANGE_REL: &str = "__SO_RANGE";
 pub const SOURCE_LABEL_KEY: &str = "__so_source_label";
 /// Allowed on user edges when preserve_source_terms=true and was_alias=true.
 pub const SOURCE_REL_KEY: &str = "__so_source_rel";
+
+/// The RDF subject IRI an entity was imported under.
+///
+/// Set by `rdf_data::import_data_turtle` and preferred over IRI minting by
+/// `rdf_data::export_data_turtle`, so that export → wipe → import → re-export
+/// reproduces the same subject IRIs instead of re-minting them from freshly
+/// assigned node ids.
+pub const SOURCE_IRI_KEY: &str = "__so_iri";

--- a/crates/sparrowdb-ontology-core/src/rdf_data.rs
+++ b/crates/sparrowdb-ontology-core/src/rdf_data.rs
@@ -195,6 +195,10 @@ pub struct ExportReport {
     pub orphan_relation_types: Vec<String>,
     /// Edges whose source or target node no longer exists.
     pub dangling_edges: usize,
+    /// Classes or entities whose name/IRI could not be turned into a valid
+    /// RDF IRI (e.g. a class name containing a space). Skipped rather than
+    /// failing the whole export — see `issues` for detail.
+    pub unrepresentable_iris: usize,
     pub issues: Vec<ExportIssue>,
 }
 
@@ -558,7 +562,22 @@ fn collect_data_triples(
             });
             continue;
         };
-        let class_node = named(class_iri)?;
+        let class_node = match named(class_iri) {
+            Ok(n) => n,
+            Err(e) => {
+                report.unrepresentable_iris += 1;
+                report.issues.push(ExportIssue {
+                    subject: label.clone(),
+                    reason: format!(
+                        "class '{label}' has an IRI that could not be represented in RDF \
+                         ({e}); its nodes were not exported. Set a valid `iri` on the class \
+                         (see define_class), or rename it to avoid characters that are \
+                         invalid in an IRI."
+                    ),
+                });
+                continue;
+            }
+        };
         let empty = HashMap::new();
         let cols = idx.props_by_class.get(label).unwrap_or(&empty);
 
@@ -585,7 +604,21 @@ fn collect_data_triples(
                 None
             });
             let subject_iri = stored_iri.unwrap_or_else(|| format!("{base}/{label}/{node_id}"));
-            let subject = named(&subject_iri)?;
+            let subject = match named(&subject_iri) {
+                Ok(s) => s,
+                Err(e) => {
+                    report.unrepresentable_iris += 1;
+                    report.issues.push(ExportIssue {
+                        subject: subject_iri.clone(),
+                        reason: format!(
+                            "node id {node_id} on label '{label}' has an IRI that could not \
+                             be represented in RDF ({e}); it was not exported. This node's \
+                             edges will be reported as dangling."
+                        ),
+                    });
+                    continue;
+                }
+            };
 
             subject_by_id.insert(*node_id, subject.clone());
             report.entities_exported += 1;

--- a/crates/sparrowdb-ontology-core/src/rdf_data.rs
+++ b/crates/sparrowdb-ontology-core/src/rdf_data.rs
@@ -388,6 +388,27 @@ fn named(iri: &str) -> Result<NamedNode, SoError> {
     })
 }
 
+/// Backtick-quote a label or relationship-type for safe interpolation into a
+/// generated Cypher query (`MATCH (n:{ident}) ...`).
+///
+/// Labels and relationship types reach this module from `db.labels()` /
+/// `db.relationship_types()` — names that were, at write time, accepted
+/// verbatim by `merge_node`/`create_edge` with no character validation (they
+/// are opaque catalog keys there, not Cypher text). By the time they get
+/// here they are about to be spliced into a `format!`-built query string, so
+/// an unquoted name containing e.g. `)` or a space would corrupt the query.
+/// SparrowDB's Cypher lexer supports backtick-quoted identifiers for exactly
+/// this case, but has no escape for an embedded backtick — so a name that
+/// itself contains a backtick cannot be made safe this way and is rejected.
+fn cypher_ident(name: &str) -> Result<String, SoError> {
+    if name.contains('`') {
+        return Err(SoError::Storage(sparrowdb_common::Error::InvalidArgument(
+            format!("'{name}' contains a backtick, which cannot be safely quoted in Cypher"),
+        )));
+    }
+    Ok(format!("`{name}`"))
+}
+
 // ── Value formatting ──────────────────────────────────────────────────────────
 
 /// Format an `f64` as a valid `xsd:double` lexical form.
@@ -581,7 +602,21 @@ fn collect_data_triples(
         let empty = HashMap::new();
         let cols = idx.props_by_class.get(label).unwrap_or(&empty);
 
-        let q = format!("MATCH (n:{label}) RETURN id(n), n");
+        let quoted_label = match cypher_ident(label) {
+            Ok(q) => q,
+            Err(e) => {
+                report.unrepresentable_iris += 1;
+                report.issues.push(ExportIssue {
+                    subject: label.clone(),
+                    reason: format!(
+                        "label '{label}' cannot be safely used in a generated query ({e}); its \
+                         nodes were not exported."
+                    ),
+                });
+                continue;
+            }
+        };
+        let q = format!("MATCH (n:{quoted_label}) RETURN id(n), n");
         let result = execute_or_empty(db, &q)?;
         for row in &result.rows {
             let Some(ExecValue::Int64(node_id)) = row.first() else {
@@ -653,10 +688,22 @@ fn collect_data_triples(
                     continue; // NULL or an unrepresentable value: nothing to emit.
                 };
                 let pred_iri = property_predicate_iri(&base, prop);
-                insert_triple(
-                    &mut out,
-                    Triple::new(subject.clone(), named(&pred_iri)?, obj),
-                );
+                let pred = match named(&pred_iri) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        report.unrepresentable_iris += 1;
+                        report.issues.push(ExportIssue {
+                            subject: subject_iri.clone(),
+                            reason: format!(
+                                "property '{}' on class '{label}' has an IRI that could not \
+                                 be represented in RDF ({e}); this value was not exported.",
+                                prop.name
+                            ),
+                        });
+                        continue;
+                    }
+                };
+                insert_triple(&mut out, Triple::new(subject.clone(), pred, obj));
             }
         }
     }
@@ -679,9 +726,36 @@ fn collect_data_triples(
             });
             continue;
         };
-        let pred = named(rel_iri)?;
+        let pred = match named(rel_iri) {
+            Ok(p) => p,
+            Err(e) => {
+                report.unrepresentable_iris += 1;
+                report.issues.push(ExportIssue {
+                    subject: rel.clone(),
+                    reason: format!(
+                        "relation '{rel}' has an IRI that could not be represented in RDF \
+                         ({e}); its edges were not exported."
+                    ),
+                });
+                continue;
+            }
+        };
 
-        let q = format!("MATCH (a)-[r:{rel}]->(b) RETURN id(a), id(b)");
+        let quoted_rel = match cypher_ident(rel) {
+            Ok(q) => q,
+            Err(e) => {
+                report.unrepresentable_iris += 1;
+                report.issues.push(ExportIssue {
+                    subject: rel.clone(),
+                    reason: format!(
+                        "relation type '{rel}' cannot be safely used in a generated query \
+                         ({e}); its edges were not exported."
+                    ),
+                });
+                continue;
+            }
+        };
+        let q = format!("MATCH (a)-[r:{quoted_rel}]->(b) RETURN id(a), id(b)");
         let result = execute_or_empty(db, &q)?;
         for row in &result.rows {
             let (Some(ExecValue::Int64(src)), Some(ExecValue::Int64(dst))) =
@@ -759,9 +833,15 @@ pub fn export_data_json_ld(db: &GraphDb, base_iri: &str) -> Result<JsVal, SoErro
     let mut context = JsMap::new();
     context.insert("xsd".into(), json!(XSD_NS));
 
-    // Relations: object properties.
+    // Relations: object properties. Sorted for deterministic @context output —
+    // idx.relation_iri is a HashMap, and if serde_json ever gains
+    // preserve_order, HashMap iteration order would otherwise leak into the
+    // serialized document and vary across runs.
     let mut relation_term_by_iri: HashMap<String, String> = HashMap::new();
-    for (name, iri) in &idx.relation_iri {
+    let mut relation_names: Vec<&String> = idx.relation_iri.keys().collect();
+    relation_names.sort();
+    for name in relation_names {
+        let iri = &idx.relation_iri[name];
         context.insert(name.clone(), json!({ "@id": iri, "@type": "@id" }));
         relation_term_by_iri.insert(iri.clone(), name.clone());
     }
@@ -786,7 +866,7 @@ pub fn export_data_json_ld(db: &GraphDb, base_iri: &str) -> Result<JsVal, SoErro
         prop_term_by_iri.insert(iri, p.name.clone());
     }
     for p in &snap.properties {
-        if conflicting.contains(&p.name) || relation_term_by_iri.contains_key(&p.name) {
+        if conflicting.contains(&p.name) || idx.relation_iri.contains_key(&p.name) {
             prop_term_by_iri.remove(&property_predicate_iri(&base, p));
             continue;
         }
@@ -890,9 +970,16 @@ fn sv(s: &str) -> StoreValue {
     StoreValue::Bytes(s.as_bytes().to_vec())
 }
 
-/// Mirror of the MCP layer's `property_value_to_store`, so that entities written
-/// by import read back byte-identically to entities written by `create_entity`.
-fn property_value_to_store(v: &PropertyValue) -> Option<StoreValue> {
+/// The single conversion from a [`PropertyValue`] to the [`StoreValue`] bytes
+/// SparrowDB stores. The MCP layer's `create_entity`/`update_entity` call this
+/// directly rather than keeping their own copy — a second, drifted
+/// implementation would mean entities written by import and entities written
+/// by `create_entity` are encoded differently and read back with different
+/// shapes. `Float64` is the fragile arm: it must go through [`fmt_f64`], not
+/// a bare `to_string()`, so `f64::INFINITY`/`NEG_INFINITY` round-trip through
+/// the XSD lexical forms (`INF`/`-INF`) that [`lexical_form`] expects on
+/// export, instead of Rust's `Display` output (`inf`/`-inf`).
+pub fn property_value_to_store(v: &PropertyValue) -> Option<StoreValue> {
     match v {
         PropertyValue::String(s) => Some(StoreValue::Bytes(s.as_bytes().to_vec())),
         PropertyValue::Int64(n) => Some(StoreValue::Int64(*n)),
@@ -990,6 +1077,13 @@ pub fn import_data_turtle(
         let pred = triple.predicate.as_str().to_string();
         match &triple.object {
             Term::NamedNode(n) if pred == RDF_TYPE => {
+                if let Some(prev) = &entry.type_iri {
+                    report.warnings.push(format!(
+                        "<{subject_iri}> has more than one rdf:type; <{prev}> was dropped and \
+                         <{}> was used. SparrowOntology v1 assigns one class per entity.",
+                        n.as_str()
+                    ));
+                }
                 entry.type_iri = Some(n.as_str().to_string());
             }
             Term::NamedNode(n) => entry.links.push((pred, n.as_str().to_string())),
@@ -1030,6 +1124,17 @@ pub fn import_data_turtle(
             continue;
         }
         let local = local_name(type_iri);
+        if local.is_empty() {
+            report.entities_skipped += 1;
+            report.skips.push(ImportSkip {
+                subject: iri.clone(),
+                reason: format!(
+                    "rdf:type <{type_iri}> has no local name. Use a type IRI that ends in a \
+                     name, for example <{type_iri}Person>."
+                ),
+            });
+            continue;
+        }
         if let Ok(r) = resolve(db, &local, AliasKind::Class) {
             class_of.insert(iri.clone(), r.canonical_name);
             continue;
@@ -1060,8 +1165,17 @@ pub fn import_data_turtle(
     }
 
     // ── Auto-declare missing data properties ──────────────────────────────────
+    //
+    // `idx` is only rebuilt after this loop (see `added` below), so a property
+    // declared for one subject is invisible to `idx` for every later subject in
+    // the same pass. Track what THIS pass has already declared in
+    // `declared_this_pass` so a second subject of the same class carrying the
+    // same property is recognised locally instead of re-declaring it — which
+    // would otherwise hit `SoError::DuplicateProperty` and (via `?`) abort the
+    // entire import over data that was already handled correctly.
     if strategy == ImportStrategy::AutoDeclare {
         let mut added = false;
+        let mut declared_this_pass: HashSet<(String, String)> = HashSet::new();
         for (iri, data) in &subjects {
             let Some(class) = class_of.get(iri) else {
                 continue;
@@ -1077,11 +1191,14 @@ pub fn import_data_turtle(
                     .get(class)
                     .map(|m| m.contains_key(&name))
                     .unwrap_or(false);
-                if declared || name.starts_with("__so_") {
+                if declared
+                    || name.starts_with("__so_")
+                    || !declared_this_pass.insert((class.clone(), name.clone()))
+                {
                     continue;
                 }
                 let ty = xsd_to_type_str(lit.datatype().as_str());
-                crate::init::add_property(
+                match crate::init::add_property(
                     db,
                     class,
                     &name,
@@ -1091,9 +1208,16 @@ pub fn import_data_turtle(
                     None,
                     None,
                     Some(pred),
-                )?;
-                report.properties_declared += 1;
-                added = true;
+                ) {
+                    Ok(_) => {
+                        report.properties_declared += 1;
+                        added = true;
+                    }
+                    // Already declared by a concurrent/earlier caller outside
+                    // this pass's own tracking — not an error for import.
+                    Err(SoError::DuplicateProperty { .. }) => {}
+                    Err(e) => return Err(e),
+                }
             }
         }
         if added {
@@ -1102,8 +1226,15 @@ pub fn import_data_turtle(
     }
 
     // ── Auto-declare missing relations ────────────────────────────────────────
+    //
+    // Same staleness issue as the property pass above: track relation names
+    // this pass has already declared so a repeat only counts once in
+    // `report.relations_declared` (write_relation_node itself is a safe
+    // upsert via merge_node, so a repeat doesn't error — it just shouldn't be
+    // double-counted).
     if strategy == ImportStrategy::AutoDeclare {
         let mut added = false;
+        let mut declared_this_pass: HashSet<String> = HashSet::new();
         for (iri, data) in &subjects {
             let Some(src_class) = class_of.get(iri) else {
                 continue;
@@ -1120,6 +1251,7 @@ pub fn import_data_turtle(
                         .get(src_class)
                         .map(|m| m.contains_key(&name))
                         .unwrap_or(false)
+                    || !declared_this_pass.insert(name.clone())
                 {
                     continue;
                 }

--- a/crates/sparrowdb-ontology-core/src/rdf_data.rs
+++ b/crates/sparrowdb-ontology-core/src/rdf_data.rs
@@ -1,0 +1,1388 @@
+//! Instance-data RDF export and import (WS1).
+//!
+//! Where [`crate::jsonld::export_json_ld`] projects the *schema* (owl:Class,
+//! owl:ObjectProperty, …), this module projects the *data*: the actual entity
+//! nodes and relationship edges stored in a SparrowDB database.
+//!
+//! This mirrors Vault-LD's two-file convention: `schema.ttl` comes from
+//! `export_json_ld` / the schema layer, `data.ttl` comes from
+//! [`export_data_turtle`].
+//!
+//! # Public API
+//!
+//! - [`export_data_turtle`] — entities and relationships as Turtle.
+//! - [`export_data_json_ld`] — the same graph as JSON-LD 1.1.
+//! - [`import_data_turtle`] — the inverse, through the validated write path.
+//! - [`export_data_with_report`] — Turtle plus an [`ExportReport`] describing
+//!   everything that could *not* be represented (orphans, dangling edges).
+//!
+//! # IRI minting and round-trip stability
+//!
+//! An entity's subject IRI is, in priority order:
+//!
+//! 1. the IRI stored on the entity in the reserved
+//!    [`SOURCE_IRI_KEY`](crate::namespace::SOURCE_IRI_KEY) (`__so_iri`) property, if present;
+//! 2. otherwise minted as `{base_iri}/{ClassName}/{node_id}`.
+//!
+//! [`import_data_turtle`] *persists* the subject IRI it read onto each entity
+//! it creates. That is what makes `export → wipe → import → re-export`
+//! reproduce the same subject IRIs: minting only ever happens on the first
+//! export of a never-imported entity. Without this, re-import would assign
+//! fresh node ids, mint different IRIs, and the second export would not be
+//! isomorphic to the first.
+//!
+//! Export itself is strictly **read-only** — it never writes minted IRIs back
+//! to the database.
+//!
+//! `node_id` is the full label-scoped [`sparrowdb_common::NodeId`]
+//! (`(label_id << 32) | slot`), never the bare slot. Organisation slot 0 and
+//! Person slot 0 are different nodes with ids `0` and `4294967296`; using the
+//! bare slot would collapse them onto one subject.
+//!
+//! # Datatype mapping
+//!
+//! Ontology [`PropertyType`] → XSD datatype used on export:
+//!
+//! | `PropertyType` | XSD datatype on export        | Notes |
+//! |----------------|-------------------------------|-------|
+//! | `String`       | `xsd:string`                  | |
+//! | `Int64`        | `xsd:integer`                 | import also accepts int/long/short/byte/unsigned*/nonNegativeInteger/… |
+//! | `Float64`      | `xsd:double`                  | import also accepts `xsd:decimal`, `xsd:float` |
+//! | `Bool`         | `xsd:boolean`                 | stored as `Int64` 0/1, emitted as `false`/`true` |
+//! | `Date`         | `xsd:date` or `xsd:dateTime`  | chosen by lexical form — see below |
+//! | `Variant`      | `xsd:string`                  | lossy: re-import yields `String`, not `Variant` |
+//!
+//! This table is the inverse of
+//! [`crate::turtle_import::xsd_to_type_str`]. The two are in different modules,
+//! so they are pinned together by
+//! `tests::datatype_mapping_is_a_fixed_point`, which round-trips every
+//! `PropertyType` through export → `xsd_to_type_str` → `property_type_from_str`
+//! and asserts the result is unchanged. If either side is edited without the
+//! other, that test fails.
+//!
+//! ## `xsd:date` vs `xsd:dateTime`
+//!
+//! `PropertyType::Date` covers both, because `xsd_to_type_str` maps *both*
+//! `xsd:date` and `xsd:dateTime` onto `"date"`, and dates are stored as plain
+//! strings (`validation.rs`: "dates stored as strings in v1" — `PropertyValue`
+//! has no `Date` variant).
+//!
+//! Emitting a stored `"2026-03-01T09:30:00Z"` as `^^xsd:date` would produce an
+//! **ill-typed literal** — a malformed lexical form for that datatype. So the
+//! exporter inspects the stored lexical form and emits `xsd:dateTime` when the
+//! value carries a time component and `xsd:date` otherwise. This keeps every
+//! emitted literal well-formed and makes date round-trips exact. See
+//! [`date_datatype_for`].
+//!
+//! # Only ontology-declared properties are exportable
+//!
+//! SparrowDB stores property names as `col_<fnv1a32(name)>` column keys, and
+//! that hash is **one-way**. To read a property back *by name* this module
+//! builds a reverse table: it takes every property the ontology declares (via
+//! [`export_schema`]), hashes each name, and matches the resulting `col_` key.
+//!
+//! The consequence is a real limit: a property written directly through the
+//! low-level `WriteTx` API without a matching ontology declaration cannot be
+//! recovered by name and therefore cannot be exported. Such columns are
+//! **counted and reported** as [`ExportReport::orphan_properties`] rather than
+//! dropped in silence.
+//!
+//! # Non-goals (WS1)
+//!
+//! No SPARQL engine, no named graphs, no reasoning, and no blank-node
+//! preservation on import — blank nodes are flagged in the report and skipped,
+//! per the spirit of Vault-LD §5.6.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use oxrdf::{Literal, NamedNode, Term, Triple};
+use serde_json::{json, Map as JsMap, Value as JsVal};
+use sparrowdb::GraphDb;
+use sparrowdb_common::NodeId;
+use sparrowdb_execution::Value as ExecValue;
+use sparrowdb_storage::node_store::Value as StoreValue;
+
+use crate::error::SoError;
+use crate::model::{AliasKind, OntologyProperty, PropertyType, PropertyValue};
+use crate::namespace::{SOURCE_IRI_KEY, SOURCE_LABEL_KEY, SO_NAMESPACE};
+use crate::resolution::resolve;
+use crate::snapshot::{export_schema, SchemaSnapshot};
+use crate::turtle_import::{write_class_node, write_relation_node, xsd_to_type_str};
+use crate::validation::ValidationContext;
+
+// ── Vocabulary constants ──────────────────────────────────────────────────────
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
+
+const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+const XSD_DATE: &str = "http://www.w3.org/2001/XMLSchema#date";
+const XSD_DATE_TIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+// ── Datatype mapping ──────────────────────────────────────────────────────────
+
+/// Map an ontology [`PropertyType`] to the XSD datatype IRI used on export.
+///
+/// This is the inverse of [`crate::turtle_import::xsd_to_type_str`]; see the
+/// module docs for the full table and for the anti-drift test that pins the two
+/// together.
+pub fn property_type_to_xsd(t: &PropertyType) -> &'static str {
+    match t {
+        PropertyType::String => XSD_STRING,
+        PropertyType::Int64 => XSD_INTEGER,
+        PropertyType::Float64 => XSD_DOUBLE,
+        PropertyType::Bool => XSD_BOOLEAN,
+        PropertyType::Date => XSD_DATE,
+        // Variant carries no static type information; export as a plain string.
+        // Lossy: a re-import sees xsd:string and yields PropertyType::String.
+        PropertyType::Variant => XSD_STRING,
+    }
+}
+
+/// Choose `xsd:date` or `xsd:dateTime` for a `PropertyType::Date` value by
+/// looking at its stored lexical form.
+///
+/// Dates are stored as strings, so a `Date` property may legitimately hold
+/// either. Emitting a `dateTime` lexical form tagged `^^xsd:date` would be an
+/// ill-typed literal, so the datatype follows the value.
+fn date_datatype_for(lexical: &str) -> &'static str {
+    // xsd:dateTime requires a 'T' separator between the date and time parts.
+    if lexical.contains('T') {
+        XSD_DATE_TIME
+    } else {
+        XSD_DATE
+    }
+}
+
+/// SparrowDB stores user-facing property names as `col_<fnv1a32(name)>`.
+/// The hash is one-way, so reading a property *by name* requires hashing each
+/// ontology-declared name and matching the resulting key.
+fn prop_name_to_col(name: &str) -> String {
+    let mut hash: u32 = 2166136261u32;
+    for byte in name.bytes() {
+        hash ^= byte as u32;
+        hash = hash.wrapping_mul(16777619);
+    }
+    format!("col_{hash}")
+}
+
+// ── Public report types ───────────────────────────────────────────────────────
+
+/// Something the exporter could not represent in RDF.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ExportIssue {
+    /// Subject IRI (or label / relationship type) the issue concerns.
+    pub subject: String,
+    /// Actionable description.
+    pub reason: String,
+}
+
+/// What [`export_data_with_report`] could not express in RDF.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct ExportReport {
+    pub entities_exported: usize,
+    pub relationships_exported: usize,
+    pub triples_emitted: usize,
+    /// Stored columns with no matching ontology-declared property name. The
+    /// `col_<hash>` key cannot be reversed, so these cannot be named in RDF.
+    pub orphan_properties: usize,
+    /// Node labels present in the database with no matching ontology class.
+    pub orphan_labels: Vec<String>,
+    /// Relationship types present in the database with no matching relation.
+    pub orphan_relation_types: Vec<String>,
+    /// Edges whose source or target node no longer exists.
+    pub dangling_edges: usize,
+    pub issues: Vec<ExportIssue>,
+}
+
+/// How [`import_data_turtle`] treats classes, relations, and properties that
+/// the ontology does not already declare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportStrategy {
+    /// Reject unknown classes / relations / properties. The offending subject
+    /// is skipped and reported; nothing is added to the ontology.
+    Strict,
+    /// Declare unknown classes, relations, and properties on the fly, deriving
+    /// property types from the literal's XSD datatype and relation domain /
+    /// range from the observed subject and object classes.
+    AutoDeclare,
+}
+
+/// One subject (or triple) that was not imported, and why.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ImportSkip {
+    /// The offending subject IRI.
+    pub subject: String,
+    /// Actionable reason, in the style of the ontology's other error messages.
+    pub reason: String,
+}
+
+/// Outcome of [`import_data_turtle`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct ImportReport {
+    pub entities_imported: usize,
+    pub relationships_imported: usize,
+    pub entities_skipped: usize,
+    pub relationships_skipped: usize,
+    /// Blank-node subjects or objects encountered. WS1 flags and skips them.
+    pub blank_nodes_skipped: usize,
+    pub classes_declared: usize,
+    pub relations_declared: usize,
+    pub properties_declared: usize,
+    /// Every skip, with the offending subject IRI and an actionable reason.
+    pub skips: Vec<ImportSkip>,
+    /// Non-fatal notes (dropped language tags, parse errors on single triples).
+    pub warnings: Vec<String>,
+}
+
+// ── Schema-derived lookup tables ──────────────────────────────────────────────
+
+/// Everything the exporter and importer need to translate between ontology
+/// names and IRIs, derived once from a single [`export_schema`] call.
+struct SchemaIndex {
+    /// class name → class IRI
+    class_iri: HashMap<String, String>,
+    /// relation name → relation IRI
+    relation_iri: HashMap<String, String>,
+    /// relation name → (domain class, range class)
+    relation_domain_range: HashMap<String, (String, String)>,
+    /// class name → (col key → property), including inherited properties.
+    props_by_class: HashMap<String, HashMap<String, OntologyProperty>>,
+    /// class name → (property name → property), including inherited.
+    props_by_name: HashMap<String, HashMap<String, OntologyProperty>>,
+    /// class IRI → class name (for import type resolution)
+    class_by_iri: HashMap<String, String>,
+    /// relation IRI → relation name (for import predicate resolution)
+    relation_by_iri: HashMap<String, String>,
+    /// property source IRI → property name (for import predicate resolution)
+    property_by_iri: HashMap<String, String>,
+}
+
+impl SchemaIndex {
+    fn build(snap: &SchemaSnapshot, base: &str) -> Self {
+        let mut class_iri = HashMap::new();
+        let mut class_by_iri = HashMap::new();
+        for c in &snap.classes {
+            let iri = match &c.iri {
+                Some(s) if !s.is_empty() => s.clone(),
+                // Deliberately NOT `so:{symbol_id}` (what the schema exporter
+                // falls back to): symbol_id is a fresh UUID on every init, so a
+                // symbol_id-derived IRI is not stable across a schema replay
+                // and would break round-trip isomorphism. A name-derived IRI is
+                // deterministic. Declare an explicit `iri` on the class to make
+                // data.ttl and schema.ttl agree exactly.
+                _ => format!("{base}/schema/{}", c.name),
+            };
+            class_by_iri.insert(iri.clone(), c.name.clone());
+            class_iri.insert(c.name.clone(), iri);
+        }
+
+        let mut relation_iri = HashMap::new();
+        let mut relation_by_iri = HashMap::new();
+        let mut relation_domain_range = HashMap::new();
+        for r in &snap.relations {
+            let iri = match &r.iri {
+                Some(s) if !s.is_empty() => s.clone(),
+                _ => format!("{base}/schema/{}", r.name),
+            };
+            relation_by_iri.insert(iri.clone(), r.name.clone());
+            relation_iri.insert(r.name.clone(), iri);
+            relation_domain_range.insert(r.name.clone(), (r.domain.clone(), r.range.clone()));
+        }
+
+        // class symbol_id → name, and child → parent for inheritance walking.
+        let name_by_sid: HashMap<&str, &str> = snap
+            .classes
+            .iter()
+            .map(|c| (c.symbol_id.as_str(), c.name.as_str()))
+            .collect();
+        let parent_of: HashMap<&str, &str> = snap
+            .subclass_edges
+            .iter()
+            .map(|(child, parent)| (child.as_str(), parent.as_str()))
+            .collect();
+
+        // Own properties per class symbol_id.
+        let mut own: HashMap<&str, Vec<&OntologyProperty>> = HashMap::new();
+        let mut property_by_iri = HashMap::new();
+        for p in &snap.properties {
+            own.entry(p.owner_symbol_id.as_str()).or_default().push(p);
+            if let Some(src) = &p.source_iri {
+                if !src.is_empty() {
+                    property_by_iri.insert(src.clone(), p.name.clone());
+                }
+            }
+        }
+
+        let mut props_by_class = HashMap::new();
+        let mut props_by_name = HashMap::new();
+        for c in &snap.classes {
+            // Walk from the most distant ancestor down to the class itself so
+            // that a child-declared property overwrites an inherited one.
+            let mut chain: Vec<&str> = Vec::new();
+            let mut cursor = c.symbol_id.as_str();
+            let mut guard = 0;
+            loop {
+                chain.push(cursor);
+                match parent_of.get(cursor) {
+                    Some(p) if guard < 32 && name_by_sid.contains_key(*p) => {
+                        cursor = p;
+                        guard += 1;
+                    }
+                    _ => break,
+                }
+            }
+            chain.reverse();
+
+            let mut by_name: HashMap<String, OntologyProperty> = HashMap::new();
+            for sid in chain {
+                for p in own.get(sid).into_iter().flatten() {
+                    by_name.insert(p.name.clone(), (*p).clone());
+                }
+            }
+            let by_col: HashMap<String, OntologyProperty> = by_name
+                .values()
+                .map(|p| (prop_name_to_col(&p.name), p.clone()))
+                .collect();
+            props_by_class.insert(c.name.clone(), by_col);
+            props_by_name.insert(c.name.clone(), by_name);
+        }
+
+        Self {
+            class_iri,
+            relation_iri,
+            relation_domain_range,
+            props_by_class,
+            props_by_name,
+            class_by_iri,
+            relation_by_iri,
+            property_by_iri,
+        }
+    }
+}
+
+/// Trim a trailing `/` so `{base}/{Class}/{id}` never doubles the separator.
+fn normalize_base(base_iri: &str) -> String {
+    base_iri.trim_end_matches('/').to_string()
+}
+
+/// Extract the local name from an IRI (everything after the last `#` or `/`).
+fn local_name(iri: &str) -> String {
+    iri.rfind(['#', '/'])
+        .map(|pos| iri[pos + 1..].to_owned())
+        .unwrap_or_else(|| iri.to_owned())
+}
+
+fn named(iri: &str) -> Result<NamedNode, SoError> {
+    NamedNode::new(iri).map_err(|e| {
+        SoError::Storage(sparrowdb_common::Error::InvalidArgument(format!(
+            "cannot build a valid IRI from '{iri}': {e}"
+        )))
+    })
+}
+
+// ── Value formatting ──────────────────────────────────────────────────────────
+
+/// Format an `f64` as a valid `xsd:double` lexical form.
+///
+/// Rust's `f64::to_string` yields `1250.5` and `2` (not `2.0`); both are valid
+/// `xsd:double` lexical forms and both re-parse to the same `f64`, so the
+/// round-trip is stable.
+fn fmt_f64(f: f64) -> String {
+    if f.is_nan() {
+        "NaN".to_string()
+    } else if f.is_infinite() {
+        if f > 0.0 { "INF" } else { "-INF" }.to_string()
+    } else {
+        f.to_string()
+    }
+}
+
+/// Render a stored value as the RDF lexical form for its *declared* type.
+///
+/// The declared [`PropertyType`] governs, not the storage representation: a
+/// `Bool` is stored as `Int64` 0/1 and a `Float64` is stored as a byte string,
+/// so the runtime `ExecValue` variant alone cannot tell you the RDF datatype.
+fn lexical_form(t: &PropertyType, v: &ExecValue) -> Option<String> {
+    match (t, v) {
+        (_, ExecValue::Null) => None,
+
+        (PropertyType::Bool, ExecValue::Int64(n)) => {
+            Some(if *n != 0 { "true" } else { "false" }.to_string())
+        }
+        (PropertyType::Bool, ExecValue::Bool(b)) => Some(b.to_string()),
+        (PropertyType::Bool, ExecValue::String(s)) => match s.as_str() {
+            "true" | "1" => Some("true".to_string()),
+            "false" | "0" => Some("false".to_string()),
+            _ => None,
+        },
+
+        (PropertyType::Int64, ExecValue::Int64(n)) => Some(n.to_string()),
+        (PropertyType::Int64, ExecValue::String(s)) => s.parse::<i64>().ok().map(|n| n.to_string()),
+        (PropertyType::Int64, ExecValue::Float64(f)) => Some((*f as i64).to_string()),
+
+        (PropertyType::Float64, ExecValue::Float64(f)) => Some(fmt_f64(*f)),
+        (PropertyType::Float64, ExecValue::String(s)) => s.parse::<f64>().ok().map(fmt_f64),
+        (PropertyType::Float64, ExecValue::Int64(n)) => Some(fmt_f64(*n as f64)),
+
+        (_, ExecValue::String(s)) => Some(s.clone()),
+        (_, ExecValue::Int64(n)) => Some(n.to_string()),
+        (_, ExecValue::Float64(f)) => Some(fmt_f64(*f)),
+        (_, ExecValue::Bool(b)) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Build the RDF object term for a declared property and its stored value.
+fn object_term(t: &PropertyType, v: &ExecValue) -> Option<Term> {
+    let lex = lexical_form(t, v)?;
+    let dt = match t {
+        PropertyType::Date => date_datatype_for(&lex),
+        other => property_type_to_xsd(other),
+    };
+    let dt_node = NamedNode::new(dt).ok()?;
+    Some(Term::Literal(Literal::new_typed_literal(lex, dt_node)))
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+/// Export every entity and relationship as Turtle.
+///
+/// Subjects, predicates, and datatypes are derived from the ontology; see the
+/// module docs for IRI minting rules and the datatype table.
+///
+/// Note the signature takes `db` first, matching
+/// [`crate::jsonld::export_json_ld`]; the spec writes it as
+/// `export_data_turtle(base_iri)` but the database is not implicit anywhere
+/// else in this crate.
+///
+/// # Errors
+/// Returns `SoError` if a schema read fails or `base_iri` cannot form valid IRIs.
+pub fn export_data_turtle(db: &GraphDb, base_iri: &str) -> Result<String, SoError> {
+    Ok(export_data_with_report(db, base_iri)?.0)
+}
+
+/// Like [`export_data_turtle`], but also returns the [`ExportReport`] listing
+/// everything that could not be represented (orphan columns, orphan labels,
+/// dangling edges).
+pub fn export_data_with_report(
+    db: &GraphDb,
+    base_iri: &str,
+) -> Result<(String, ExportReport), SoError> {
+    let (triples, report) = collect_data_triples(db, base_iri)?;
+
+    let mut ser = oxttl::TurtleSerializer::new();
+    for (prefix, ns) in [
+        ("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
+        ("xsd", XSD_NS),
+    ] {
+        ser = ser
+            .with_prefix(prefix, ns)
+            .map_err(|e| invalid(format!("bad prefix {prefix}: {e}")))?;
+    }
+
+    let mut writer = ser.for_writer(Vec::new());
+    for t in &triples {
+        writer
+            .serialize_triple(t.as_ref())
+            .map_err(|e| invalid(format!("Turtle serialization failed: {e}")))?;
+    }
+    let bytes = writer
+        .finish()
+        .map_err(|e| invalid(format!("Turtle serialization failed: {e}")))?;
+    let ttl = String::from_utf8(bytes)
+        .map_err(|e| invalid(format!("Turtle output was not valid UTF-8: {e}")))?;
+
+    Ok((ttl, report))
+}
+
+fn invalid(msg: String) -> SoError {
+    SoError::Storage(sparrowdb_common::Error::InvalidArgument(msg))
+}
+
+/// Run a query, treating "unknown label"/"unknown relationship type" as empty.
+fn execute_or_empty(db: &GraphDb, q: &str) -> Result<sparrowdb_execution::QueryResult, SoError> {
+    match db.execute(q) {
+        Ok(r) => Ok(r),
+        Err(sparrowdb_common::Error::InvalidArgument(ref msg))
+            if msg.contains("unknown label") || msg.contains("unknown relationship type") =>
+        {
+            Ok(sparrowdb_execution::QueryResult::empty(vec![]))
+        }
+        Err(e) => Err(SoError::Storage(e)),
+    }
+}
+
+/// Build the deduplicated, deterministically ordered triple list for the data graph.
+///
+/// Triples are keyed by their N-Triples form in a `BTreeMap`, which dedupes
+/// (RDF graphs are sets — a duplicate edge in storage must not become a
+/// duplicate triple) and yields a stable order across runs.
+fn collect_data_triples(
+    db: &GraphDb,
+    base_iri: &str,
+) -> Result<(Vec<Triple>, ExportReport), SoError> {
+    let base = normalize_base(base_iri);
+    let snap = export_schema(db)?;
+    let idx = SchemaIndex::build(&snap, &base);
+
+    let mut report = ExportReport::default();
+    let mut out: BTreeMap<String, Triple> = BTreeMap::new();
+
+    let rdf_type = named(RDF_TYPE)?;
+    let iri_col = prop_name_to_col(SOURCE_IRI_KEY);
+    let source_label_col = prop_name_to_col(SOURCE_LABEL_KEY);
+
+    // node id → subject IRI, for edge endpoints. Also doubles as the "this node
+    // is live" set used to filter dangling edges.
+    let mut subject_by_id: HashMap<i64, NamedNode> = HashMap::new();
+
+    // ── Entities ──────────────────────────────────────────────────────────────
+    let mut labels = db.labels().map_err(SoError::Storage)?;
+    labels.sort();
+    for label in &labels {
+        if label.starts_with(SO_NAMESPACE) {
+            continue;
+        }
+        let Some(class_iri) = idx.class_iri.get(label) else {
+            report.orphan_labels.push(label.clone());
+            report.issues.push(ExportIssue {
+                subject: label.clone(),
+                reason: format!(
+                    "Label '{label}' is not a declared ontology class; its nodes were not \
+                     exported. Declare it with define_class, or remove the nodes."
+                ),
+            });
+            continue;
+        };
+        let class_node = named(class_iri)?;
+        let empty = HashMap::new();
+        let cols = idx.props_by_class.get(label).unwrap_or(&empty);
+
+        let q = format!("MATCH (n:{label}) RETURN id(n), n");
+        let result = execute_or_empty(db, &q)?;
+        for row in &result.rows {
+            let Some(ExecValue::Int64(node_id)) = row.first() else {
+                continue;
+            };
+            let props: &Vec<(String, ExecValue)> = match row.get(1) {
+                Some(ExecValue::Map(m)) => m,
+                _ => continue,
+            };
+
+            // Subject IRI: stored __so_iri wins over minting.
+            let stored_iri = props.iter().find_map(|(k, v)| {
+                if k == &iri_col {
+                    if let ExecValue::String(s) = v {
+                        if !s.is_empty() {
+                            return Some(s.clone());
+                        }
+                    }
+                }
+                None
+            });
+            let subject_iri = stored_iri.unwrap_or_else(|| format!("{base}/{label}/{node_id}"));
+            let subject = named(&subject_iri)?;
+
+            subject_by_id.insert(*node_id, subject.clone());
+            report.entities_exported += 1;
+
+            insert_triple(
+                &mut out,
+                Triple::new(subject.clone(), rdf_type.clone(), class_node.clone()),
+            );
+
+            for (col_key, value) in props {
+                if col_key == &iri_col || col_key == &source_label_col {
+                    // The subject IRI and the alias-provenance marker are
+                    // bookkeeping, not data properties.
+                    continue;
+                }
+                let Some(prop) = cols.get(col_key) else {
+                    // col_<hash> is one-way: with no ontology declaration whose
+                    // name hashes to this key, the property cannot be named.
+                    report.orphan_properties += 1;
+                    report.issues.push(ExportIssue {
+                        subject: subject_iri.clone(),
+                        reason: format!(
+                            "Stored column '{col_key}' has no ontology-declared property on \
+                             class '{label}'. Property names hash one-way to col_<fnv1a32>, so \
+                             this value cannot be named in RDF. Declare it with \
+                             add_property(owner='{label}', …) and re-export."
+                        ),
+                    });
+                    continue;
+                };
+                let Some(obj) = object_term(&prop.datatype, value) else {
+                    continue; // NULL or an unrepresentable value: nothing to emit.
+                };
+                let pred_iri = property_predicate_iri(&base, prop);
+                insert_triple(
+                    &mut out,
+                    Triple::new(subject.clone(), named(&pred_iri)?, obj),
+                );
+            }
+        }
+    }
+
+    // ── Relationships ─────────────────────────────────────────────────────────
+    let mut rel_types = db.relationship_types().map_err(SoError::Storage)?;
+    rel_types.sort();
+    for rel in &rel_types {
+        if rel.starts_with(SO_NAMESPACE) {
+            continue;
+        }
+        let Some(rel_iri) = idx.relation_iri.get(rel) else {
+            report.orphan_relation_types.push(rel.clone());
+            report.issues.push(ExportIssue {
+                subject: rel.clone(),
+                reason: format!(
+                    "Relationship type '{rel}' is not a declared ontology relation; its edges \
+                     were not exported. Declare it with define_relation."
+                ),
+            });
+            continue;
+        };
+        let pred = named(rel_iri)?;
+
+        let q = format!("MATCH (a)-[r:{rel}]->(b) RETURN id(a), id(b)");
+        let result = execute_or_empty(db, &q)?;
+        for row in &result.rows {
+            let (Some(ExecValue::Int64(src)), Some(ExecValue::Int64(dst))) =
+                (row.first(), row.get(1))
+            else {
+                continue;
+            };
+            // Deleting a node through Cypher `MATCH … DELETE` leaves its edges
+            // behind (SparrowDB 0.1.22), so an edge endpoint may name a node
+            // that no longer exists. Emitting a triple for it would assert
+            // facts about a deleted entity.
+            let (Some(s), Some(o)) = (subject_by_id.get(src), subject_by_id.get(dst)) else {
+                report.dangling_edges += 1;
+                report.issues.push(ExportIssue {
+                    subject: format!("{src} -[{rel}]-> {dst}"),
+                    reason: "Edge references a node that no longer exists; skipped. This is \
+                             left behind by `MATCH (n:Label) DELETE n`, which does not remove \
+                             incident edges."
+                        .to_string(),
+                });
+                continue;
+            };
+            report.relationships_exported += 1;
+            insert_triple(
+                &mut out,
+                Triple::new(s.clone(), pred.clone(), Term::NamedNode(o.clone())),
+            );
+        }
+    }
+
+    let triples: Vec<Triple> = out.into_values().collect();
+    report.triples_emitted = triples.len();
+    Ok((triples, report))
+}
+
+fn insert_triple(out: &mut BTreeMap<String, Triple>, t: Triple) {
+    out.insert(t.to_string(), t);
+}
+
+/// Predicate IRI for a data property: its `source_iri` if it was imported from
+/// an external vocabulary, otherwise minted from the property *name*.
+///
+/// Minting from the name (not the owning class) is deliberate: it mirrors how
+/// RDF vocabularies work — `foaf:name` is one predicate regardless of subject
+/// class — and it lets import resolve a predicate without knowing the class first.
+fn property_predicate_iri(base: &str, prop: &OntologyProperty) -> String {
+    match &prop.source_iri {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => format!("{base}/schema/{}", prop.name),
+    }
+}
+
+// ── JSON-LD export ────────────────────────────────────────────────────────────
+
+/// Export the same graph as [`export_data_turtle`] in JSON-LD 1.1.
+///
+/// The `@context` is derived from the ontology: every declared property becomes
+/// a term with an `@type` datatype coercion, and every relation becomes a term
+/// with `"@type": "@id"`.
+///
+/// Literal values are emitted as JSON **strings** and typed by the context's
+/// coercion rules rather than by native JSON types. This guarantees the
+/// JSON-LD graph is triple-for-triple identical to the Turtle graph — a JSON
+/// number cannot express `xsd:integer` vs `xsd:double` unambiguously.
+///
+/// # Errors
+/// Returns `SoError` if a schema read fails or `base_iri` cannot form valid IRIs.
+pub fn export_data_json_ld(db: &GraphDb, base_iri: &str) -> Result<JsVal, SoError> {
+    let base = normalize_base(base_iri);
+    let snap = export_schema(db)?;
+    let idx = SchemaIndex::build(&snap, &base);
+    let (triples, _) = collect_data_triples(db, &base)?;
+
+    // ── @context ──────────────────────────────────────────────────────────────
+    let mut context = JsMap::new();
+    context.insert("xsd".into(), json!(XSD_NS));
+
+    // Relations: object properties.
+    let mut relation_term_by_iri: HashMap<String, String> = HashMap::new();
+    for (name, iri) in &idx.relation_iri {
+        context.insert(name.clone(), json!({ "@id": iri, "@type": "@id" }));
+        relation_term_by_iri.insert(iri.clone(), name.clone());
+    }
+
+    // Data properties: one term per property name, with datatype coercion.
+    // A name declared on several classes must agree on its type to be given a
+    // context term; otherwise the full IRI is used inline.
+    let mut prop_term_by_iri: HashMap<String, String> = HashMap::new();
+    let mut seen_type: HashMap<String, &'static str> = HashMap::new();
+    let mut conflicting: HashSet<String> = HashSet::new();
+    for p in &snap.properties {
+        let iri = property_predicate_iri(&base, p);
+        let xsd = property_type_to_xsd(&p.datatype);
+        match seen_type.get(&p.name) {
+            Some(prev) if *prev != xsd => {
+                conflicting.insert(p.name.clone());
+            }
+            _ => {
+                seen_type.insert(p.name.clone(), xsd);
+            }
+        }
+        prop_term_by_iri.insert(iri, p.name.clone());
+    }
+    for p in &snap.properties {
+        if conflicting.contains(&p.name) || relation_term_by_iri.contains_key(&p.name) {
+            prop_term_by_iri.remove(&property_predicate_iri(&base, p));
+            continue;
+        }
+        let iri = property_predicate_iri(&base, p);
+        let xsd = property_type_to_xsd(&p.datatype);
+        // Two cases get no `@type` coercion on the term:
+        //
+        // - Date, because the value decides between xsd:date and xsd:dateTime,
+        //   so the datatype rides on each literal instead.
+        // - xsd:string, because RDF 1.1 makes xsd:string the type of a plain
+        //   literal. Turtle writes `"Acme Corp"`; coercing the JSON-LD term to
+        //   xsd:string makes some processors (rdflib among them) produce a
+        //   *typed* literal that no longer compares equal to the plain one, and
+        //   the two serializations stop being the same graph.
+        if p.datatype == PropertyType::Date || xsd == XSD_STRING {
+            context.insert(p.name.clone(), json!({ "@id": iri }));
+        } else {
+            context.insert(p.name.clone(), json!({ "@id": iri, "@type": xsd }));
+        }
+    }
+
+    // ── @graph ────────────────────────────────────────────────────────────────
+    // Group triples by subject, preserving the deterministic order they arrive in.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_subject: HashMap<String, JsMap<String, JsVal>> = HashMap::new();
+
+    for t in &triples {
+        let subj = t.subject.to_string();
+        let subj = subj.trim_matches(|c| c == '<' || c == '>').to_string();
+        if !by_subject.contains_key(&subj) {
+            order.push(subj.clone());
+            let mut m = JsMap::new();
+            m.insert("@id".into(), json!(subj));
+            by_subject.insert(subj.clone(), m);
+        }
+        let entry = by_subject.get_mut(&subj).expect("just inserted");
+        let pred = t.predicate.as_str();
+
+        if pred == RDF_TYPE {
+            if let Term::NamedNode(n) = &t.object {
+                entry.insert("@type".into(), json!(n.as_str()));
+            }
+            continue;
+        }
+
+        let (key, value) = match &t.object {
+            Term::NamedNode(n) => {
+                let key = relation_term_by_iri
+                    .get(pred)
+                    .cloned()
+                    .unwrap_or_else(|| pred.to_string());
+                (key, json!({ "@id": n.as_str() }))
+            }
+            Term::Literal(lit) => {
+                let key = prop_term_by_iri
+                    .get(pred)
+                    .cloned()
+                    .unwrap_or_else(|| pred.to_string());
+                let dt = lit.datatype().as_str();
+                // Terms carry their coercion in @context. Dates (and any
+                // predicate that had to fall back to a full IRI) need the
+                // datatype spelled out on the value itself.
+                let needs_explicit = !context
+                    .get(&key)
+                    .and_then(|t| t.get("@type"))
+                    .map(|t| t == dt)
+                    .unwrap_or(false);
+                if needs_explicit && dt != XSD_STRING {
+                    (key, json!({ "@value": lit.value(), "@type": dt }))
+                } else {
+                    (key, json!(lit.value()))
+                }
+            }
+            // The exporter never emits blank nodes.
+            Term::BlankNode(_) => continue,
+        };
+
+        match entry.get_mut(&key) {
+            Some(JsVal::Array(arr)) => arr.push(value),
+            Some(existing) => {
+                let prev = existing.clone();
+                *existing = JsVal::Array(vec![prev, value]);
+            }
+            None => {
+                entry.insert(key, value);
+            }
+        }
+    }
+
+    let graph: Vec<JsVal> = order
+        .into_iter()
+        .filter_map(|s| by_subject.remove(&s).map(JsVal::Object))
+        .collect();
+
+    Ok(json!({ "@context": JsVal::Object(context), "@graph": graph }))
+}
+
+// ── Import ────────────────────────────────────────────────────────────────────
+
+fn sv(s: &str) -> StoreValue {
+    StoreValue::Bytes(s.as_bytes().to_vec())
+}
+
+/// Mirror of the MCP layer's `property_value_to_store`, so that entities written
+/// by import read back byte-identically to entities written by `create_entity`.
+fn property_value_to_store(v: &PropertyValue) -> Option<StoreValue> {
+    match v {
+        PropertyValue::String(s) => Some(StoreValue::Bytes(s.as_bytes().to_vec())),
+        PropertyValue::Int64(n) => Some(StoreValue::Int64(*n)),
+        PropertyValue::Float64(f) => Some(StoreValue::Bytes(fmt_f64(*f).into_bytes())),
+        PropertyValue::Bool(b) => Some(StoreValue::Int64(if *b { 1 } else { 0 })),
+        PropertyValue::Null => None,
+    }
+}
+
+/// Coerce a literal to the declared property type.
+fn literal_to_property_value(t: &PropertyType, lit: &Literal) -> Result<PropertyValue, String> {
+    let s = lit.value();
+    match t {
+        PropertyType::String | PropertyType::Date | PropertyType::Variant => {
+            Ok(PropertyValue::String(s.to_string()))
+        }
+        PropertyType::Int64 => s
+            .parse::<i64>()
+            .map(PropertyValue::Int64)
+            .map_err(|_| format!("expected an integer for a declared int64 property, got '{s}'")),
+        PropertyType::Float64 => s
+            .parse::<f64>()
+            .map(PropertyValue::Float64)
+            .map_err(|_| format!("expected a number for a declared float64 property, got '{s}'")),
+        PropertyType::Bool => match s {
+            "true" | "1" => Ok(PropertyValue::Bool(true)),
+            "false" | "0" => Ok(PropertyValue::Bool(false)),
+            other => Err(format!(
+                "expected 'true' or 'false' for a declared bool property, got '{other}'"
+            )),
+        },
+    }
+}
+
+/// Everything gathered about one subject during the parse pass.
+struct SubjectData {
+    iri: String,
+    type_iri: Option<String>,
+    literals: Vec<(String, Literal)>,
+    links: Vec<(String, String)>,
+}
+
+/// Import entities and relationships from a Turtle document.
+///
+/// Subjects whose `rdf:type` matches a known class (by IRI, or by the IRI's
+/// local name resolved through the alias table) become entities written through
+/// the ontology's validated write path. The subject IRI is persisted on each
+/// entity so a later export reproduces it exactly.
+///
+/// Nothing is dropped silently: every skipped subject or triple is recorded in
+/// [`ImportReport::skips`] with the offending subject IRI and an actionable reason.
+///
+/// # Errors
+/// Returns `SoError` only for storage-level failures that affect the whole
+/// import. Per-subject problems are collected in the report.
+pub fn import_data_turtle(
+    db: &GraphDb,
+    turtle: &str,
+    strategy: ImportStrategy,
+) -> Result<ImportReport, SoError> {
+    let mut report = ImportReport::default();
+
+    // ── Parse ─────────────────────────────────────────────────────────────────
+    // BTreeMap keeps subject processing order deterministic.
+    let mut subjects: BTreeMap<String, SubjectData> = BTreeMap::new();
+
+    for result in oxttl::TurtleParser::new().for_slice(turtle.as_bytes()) {
+        let triple = match result {
+            Ok(t) => t,
+            Err(e) => {
+                report.warnings.push(format!("Parse error: {e}"));
+                continue;
+            }
+        };
+
+        let subject_iri = match &triple.subject {
+            oxrdf::NamedOrBlankNode::NamedNode(n) => n.as_str().to_string(),
+            oxrdf::NamedOrBlankNode::BlankNode(_) => {
+                // WS1 non-goal: blank nodes are flagged and skipped, never
+                // silently dropped (Vault-LD §5.6 spirit).
+                report.blank_nodes_skipped += 1;
+                continue;
+            }
+        };
+
+        let entry = subjects
+            .entry(subject_iri.clone())
+            .or_insert_with(|| SubjectData {
+                iri: subject_iri.clone(),
+                type_iri: None,
+                literals: Vec::new(),
+                links: Vec::new(),
+            });
+
+        let pred = triple.predicate.as_str().to_string();
+        match &triple.object {
+            Term::NamedNode(n) if pred == RDF_TYPE => {
+                entry.type_iri = Some(n.as_str().to_string());
+            }
+            Term::NamedNode(n) => entry.links.push((pred, n.as_str().to_string())),
+            Term::Literal(lit) => {
+                if lit.language().is_some() {
+                    report.warnings.push(format!(
+                        "Language tag on <{subject_iri}> <{pred}> was dropped; SparrowOntology \
+                         v1 stores plain strings."
+                    ));
+                }
+                entry.literals.push((pred, lit.clone()));
+            }
+            Term::BlankNode(_) => {
+                report.blank_nodes_skipped += 1;
+            }
+        }
+    }
+
+    // ── Resolve classes ───────────────────────────────────────────────────────
+    let mut idx = SchemaIndex::build(&export_schema(db)?, "");
+
+    // subject IRI → resolved canonical class name
+    let mut class_of: BTreeMap<String, String> = BTreeMap::new();
+
+    for (iri, data) in &subjects {
+        let Some(type_iri) = &data.type_iri else {
+            report.entities_skipped += 1;
+            report.skips.push(ImportSkip {
+                subject: iri.clone(),
+                reason: "No rdf:type. Every subject needs an rdf:type naming a known class."
+                    .to_string(),
+            });
+            continue;
+        };
+
+        if let Some(name) = idx.class_by_iri.get(type_iri) {
+            class_of.insert(iri.clone(), name.clone());
+            continue;
+        }
+        let local = local_name(type_iri);
+        if let Ok(r) = resolve(db, &local, AliasKind::Class) {
+            class_of.insert(iri.clone(), r.canonical_name);
+            continue;
+        }
+
+        match strategy {
+            ImportStrategy::Strict => {
+                report.entities_skipped += 1;
+                report.skips.push(ImportSkip {
+                    subject: iri.clone(),
+                    reason: format!(
+                        "Unknown class <{type_iri}>. Valid: {:?}. Declare it with define_class, \
+                         or re-run with ImportStrategy::AutoDeclare.",
+                        sorted_keys(&idx.class_iri)
+                    ),
+                });
+            }
+            ImportStrategy::AutoDeclare => {
+                write_class_node(db, &local, "", type_iri)?;
+                report.classes_declared += 1;
+                class_of.insert(iri.clone(), local);
+            }
+        }
+    }
+
+    if report.classes_declared > 0 {
+        idx = SchemaIndex::build(&export_schema(db)?, "");
+    }
+
+    // ── Auto-declare missing data properties ──────────────────────────────────
+    if strategy == ImportStrategy::AutoDeclare {
+        let mut added = false;
+        for (iri, data) in &subjects {
+            let Some(class) = class_of.get(iri) else {
+                continue;
+            };
+            for (pred, lit) in &data.literals {
+                let name = idx
+                    .property_by_iri
+                    .get(pred)
+                    .cloned()
+                    .unwrap_or_else(|| local_name(pred));
+                let declared = idx
+                    .props_by_name
+                    .get(class)
+                    .map(|m| m.contains_key(&name))
+                    .unwrap_or(false);
+                if declared || name.starts_with("__so_") {
+                    continue;
+                }
+                let ty = xsd_to_type_str(lit.datatype().as_str());
+                crate::init::add_property(
+                    db,
+                    class,
+                    &name,
+                    ty,
+                    false,
+                    false,
+                    None,
+                    None,
+                    Some(pred),
+                )?;
+                report.properties_declared += 1;
+                added = true;
+            }
+        }
+        if added {
+            idx = SchemaIndex::build(&export_schema(db)?, "");
+        }
+    }
+
+    // ── Auto-declare missing relations ────────────────────────────────────────
+    if strategy == ImportStrategy::AutoDeclare {
+        let mut added = false;
+        for (iri, data) in &subjects {
+            let Some(src_class) = class_of.get(iri) else {
+                continue;
+            };
+            for (pred, target) in &data.links {
+                if idx.relation_by_iri.contains_key(pred) {
+                    continue;
+                }
+                let name = local_name(pred);
+                if idx.relation_iri.contains_key(&name)
+                    || idx.property_by_iri.contains_key(pred)
+                    || idx
+                        .props_by_name
+                        .get(src_class)
+                        .map(|m| m.contains_key(&name))
+                        .unwrap_or(false)
+                {
+                    continue;
+                }
+                let Some(dst_class) = class_of.get(target) else {
+                    continue; // handled as a skip in the relationship pass
+                };
+                write_relation_node(db, &name, "", pred, Some(src_class), Some(dst_class))?;
+                report.relations_declared += 1;
+                added = true;
+            }
+        }
+        if added {
+            idx = SchemaIndex::build(&export_schema(db)?, "");
+        }
+    }
+
+    // ── Create entities ───────────────────────────────────────────────────────
+    let mut node_of: HashMap<String, (NodeId, String)> = HashMap::new();
+
+    for (iri, data) in &subjects {
+        let Some(class) = class_of.get(iri) else {
+            continue; // already reported
+        };
+        let empty = HashMap::new();
+        let declared = idx.props_by_name.get(class).unwrap_or(&empty);
+
+        let mut props: HashMap<String, PropertyValue> = HashMap::new();
+        let mut failed: Option<String> = None;
+
+        for (pred, lit) in &data.literals {
+            let name = idx
+                .property_by_iri
+                .get(pred)
+                .cloned()
+                .unwrap_or_else(|| local_name(pred));
+            let Some(prop) = declared.get(&name) else {
+                failed = Some(format!(
+                    "Unknown property '{name}' (from <{pred}>) on class '{class}'. Valid: {:?}. \
+                     Declare it with add_property(owner='{class}', name='{name}'), or re-run \
+                     with ImportStrategy::AutoDeclare.",
+                    sorted_keys(declared)
+                ));
+                break;
+            };
+            match literal_to_property_value(&prop.datatype, lit) {
+                Ok(v) => {
+                    props.insert(name, v);
+                }
+                Err(e) => {
+                    failed = Some(format!("Property '{name}': {e}"));
+                    break;
+                }
+            }
+        }
+
+        if let Some(reason) = failed {
+            report.entities_skipped += 1;
+            report.skips.push(ImportSkip {
+                subject: iri.clone(),
+                reason,
+            });
+            continue;
+        }
+
+        // Validated write path — same rules create_entity enforces.
+        if let Err(e) = ValidationContext::new(db).validate_entity(class, &props, true) {
+            report.entities_skipped += 1;
+            report.skips.push(ImportSkip {
+                subject: iri.clone(),
+                reason: e.to_string(),
+            });
+            continue;
+        }
+
+        let mut store: HashMap<String, StoreValue> = props
+            .iter()
+            .filter_map(|(k, v)| property_value_to_store(v).map(|s| (k.clone(), s)))
+            .collect();
+        // Persist the subject IRI so the next export reproduces it instead of
+        // minting a new one from the freshly assigned node id.
+        store.insert(SOURCE_IRI_KEY.to_string(), sv(&data.iri));
+
+        let mut tx = db.begin_write()?;
+        let nid = tx.merge_node(class, store)?;
+        tx.commit()?;
+
+        node_of.insert(iri.clone(), (nid, class.clone()));
+        report.entities_imported += 1;
+    }
+
+    // ── Create relationships ──────────────────────────────────────────────────
+    for (iri, data) in &subjects {
+        let Some((src_id, src_class)) = node_of.get(iri) else {
+            continue;
+        };
+        for (pred, target) in &data.links {
+            let rel_name = idx
+                .relation_by_iri
+                .get(pred)
+                .cloned()
+                .unwrap_or_else(|| local_name(pred));
+
+            if !idx.relation_iri.contains_key(&rel_name) {
+                report.relationships_skipped += 1;
+                report.skips.push(ImportSkip {
+                    subject: iri.clone(),
+                    reason: format!(
+                        "Unknown relation '{rel_name}' (from <{pred}>). Valid: {:?}. Declare it \
+                         with define_relation, or re-run with ImportStrategy::AutoDeclare.",
+                        sorted_keys(&idx.relation_iri)
+                    ),
+                });
+                continue;
+            }
+
+            let Some((dst_id, dst_class)) = node_of.get(target) else {
+                report.relationships_skipped += 1;
+                report.skips.push(ImportSkip {
+                    subject: iri.clone(),
+                    reason: format!(
+                        "Relation '{rel_name}' points at <{target}>, which was not imported as \
+                         an entity (no rdf:type, or it was itself skipped)."
+                    ),
+                });
+                continue;
+            };
+
+            if let Err(e) =
+                ValidationContext::new(db).validate_relationship(&rel_name, src_class, dst_class)
+            {
+                report.relationships_skipped += 1;
+                report.skips.push(ImportSkip {
+                    subject: iri.clone(),
+                    reason: e.to_string(),
+                });
+                continue;
+            }
+
+            let mut tx = db.begin_write()?;
+            tx.create_edge(*src_id, *dst_id, &rel_name, HashMap::new())?;
+            tx.commit()?;
+            report.relationships_imported += 1;
+        }
+    }
+
+    let _ = &idx.relation_domain_range; // kept for future range-narrowing checks
+    Ok(report)
+}
+
+fn sorted_keys<V>(m: &HashMap<String, V>) -> Vec<String> {
+    let mut v: Vec<String> = m.keys().cloned().collect();
+    v.sort();
+    v
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::snapshot::property_type_from_str;
+
+    #[test]
+    fn base_iri_trailing_slash_is_normalized() {
+        assert_eq!(normalize_base("https://ex.org/kb/"), "https://ex.org/kb");
+        assert_eq!(normalize_base("https://ex.org/kb"), "https://ex.org/kb");
+    }
+
+    #[test]
+    fn local_name_handles_hash_and_slash() {
+        assert_eq!(local_name("http://xmlns.com/foaf/0.1/name"), "name");
+        assert_eq!(local_name("http://www.w3.org/2002/07/owl#Class"), "Class");
+        assert_eq!(local_name("bare"), "bare");
+    }
+
+    /// The `col_` reverse table only works if this hash matches the engine's.
+    /// Derived by hand: FNV-1a 32-bit over the ASCII bytes of "name", starting
+    /// from offset basis 2166136261 with prime 16777619. Probe of a live
+    /// SparrowDB (`MATCH (n:Person) RETURN n` on a node with name="Ada")
+    /// returned the key `col_2369371622`.
+    #[test]
+    fn fnv1a32_matches_the_engine_column_keys() {
+        assert_eq!(prop_name_to_col("name"), "col_2369371622");
+    }
+
+    /// Anti-drift guard for the datatype table.
+    ///
+    /// `property_type_to_xsd` (here) and `xsd_to_type_str` (turtle_import) live
+    /// in different modules and would otherwise be free to drift apart. Every
+    /// `PropertyType` must survive export → XSD IRI → import → `PropertyType`
+    /// unchanged, except `Variant`, which has no XSD equivalent and is
+    /// documented as collapsing to `String`.
+    ///
+    /// Expected values derived by hand from the mapping table in the module
+    /// docs, not captured from program output.
+    #[test]
+    fn datatype_mapping_is_a_fixed_point() {
+        let cases = [
+            (PropertyType::String, XSD_STRING, PropertyType::String),
+            (PropertyType::Int64, XSD_INTEGER, PropertyType::Int64),
+            (PropertyType::Float64, XSD_DOUBLE, PropertyType::Float64),
+            (PropertyType::Bool, XSD_BOOLEAN, PropertyType::Bool),
+            (PropertyType::Date, XSD_DATE, PropertyType::Date),
+            // Documented lossy edge: Variant has no XSD counterpart.
+            (PropertyType::Variant, XSD_STRING, PropertyType::String),
+        ];
+        for (from, expected_xsd, expected_back) in cases {
+            let xsd = property_type_to_xsd(&from);
+            assert_eq!(
+                xsd, expected_xsd,
+                "{from:?} should export as {expected_xsd}"
+            );
+            let back = property_type_from_str(xsd_to_type_str(xsd));
+            assert_eq!(
+                back, expected_back,
+                "{from:?} -> {xsd} should re-import as {expected_back:?}"
+            );
+        }
+    }
+
+    /// Every XSD datatype the importer accepts for a numeric/boolean/date type
+    /// must map onto the type this module exports for. Hand-derived from
+    /// `xsd_to_type_str`'s match arms.
+    #[test]
+    fn import_accepts_the_wider_xsd_families() {
+        for local in [
+            "integer",
+            "int",
+            "long",
+            "short",
+            "byte",
+            "nonNegativeInteger",
+            "positiveInteger",
+            "unsignedInt",
+        ] {
+            assert_eq!(
+                xsd_to_type_str(&format!("{XSD_NS}{local}")),
+                "int64",
+                "xsd:{local} should import as int64"
+            );
+        }
+        for local in ["decimal", "float", "double"] {
+            assert_eq!(xsd_to_type_str(&format!("{XSD_NS}{local}")), "float64");
+        }
+        assert_eq!(xsd_to_type_str(XSD_BOOLEAN), "bool");
+        assert_eq!(xsd_to_type_str(XSD_DATE), "date");
+        assert_eq!(xsd_to_type_str(XSD_DATE_TIME), "date");
+        // xsd:time has no calendar component and no Sparrow equivalent.
+        assert_eq!(xsd_to_type_str(&format!("{XSD_NS}time")), "string");
+    }
+
+    /// A `Date` property holding a dateTime lexical form must be tagged
+    /// `xsd:dateTime`, not `xsd:date` — `"2026-03-01T09:30:00Z"^^xsd:date` is
+    /// an ill-typed literal.
+    #[test]
+    fn date_datatype_follows_the_lexical_form() {
+        assert_eq!(date_datatype_for("2026-03-01"), XSD_DATE);
+        assert_eq!(date_datatype_for("2026-03-01T09:30:00Z"), XSD_DATE_TIME);
+    }
+
+    /// Bools are stored as `Int64` 0/1 and floats as byte strings, so the
+    /// declared type — not the storage variant — must drive the lexical form.
+    #[test]
+    fn lexical_form_follows_the_declared_type_not_the_storage_type() {
+        assert_eq!(
+            lexical_form(&PropertyType::Bool, &ExecValue::Int64(1)).unwrap(),
+            "true"
+        );
+        assert_eq!(
+            lexical_form(&PropertyType::Bool, &ExecValue::Int64(0)).unwrap(),
+            "false"
+        );
+        assert_eq!(
+            lexical_form(
+                &PropertyType::Float64,
+                &ExecValue::String("1250.5".to_string())
+            )
+            .unwrap(),
+            "1250.5"
+        );
+        assert_eq!(
+            lexical_form(&PropertyType::Int64, &ExecValue::Int64(7)).unwrap(),
+            "7"
+        );
+        assert_eq!(lexical_form(&PropertyType::String, &ExecValue::Null), None);
+    }
+
+    /// Whole-number doubles render without a trailing `.0`; both forms are
+    /// valid `xsd:double` and re-parse to the same value, so the round-trip is
+    /// byte-stable.
+    #[test]
+    fn f64_formatting_round_trips() {
+        for v in [1250.5f64, 2.0, -0.25, 1e10] {
+            let s = fmt_f64(v);
+            assert_eq!(s.parse::<f64>().unwrap(), v, "{s} should re-parse to {v}");
+        }
+        assert_eq!(fmt_f64(2.0), "2");
+    }
+}

--- a/crates/sparrowdb-ontology-core/src/rdf_data.rs
+++ b/crates/sparrowdb-ontology-core/src/rdf_data.rs
@@ -763,18 +763,21 @@ fn collect_data_triples(
             else {
                 continue;
             };
-            // Deleting a node through Cypher `MATCH … DELETE` leaves its edges
-            // behind (SparrowDB 0.1.22), so an edge endpoint may name a node
-            // that no longer exists. Emitting a triple for it would assert
-            // facts about a deleted entity.
+            // Defensive: an edge endpoint may in principle name a node that no
+            // longer exists, and emitting a triple for it would assert facts
+            // about a deleted entity. Not currently reachable through the
+            // public API on SparrowDB 0.1.27+ — `DELETE` on an edge-bearing
+            // node is refused outright (`NodeHasEdges`, #436/PR #512) and
+            // `DETACH DELETE` removes a node and its edges atomically, with
+            // WAL replay applying each transaction's mutations all-or-nothing
+            // (see the `dangling_edges` tests in test_rdf_data.rs). Kept for
+            // a database created under an older SparrowDB, or a future
+            // storage-layer regression.
             let (Some(s), Some(o)) = (subject_by_id.get(src), subject_by_id.get(dst)) else {
                 report.dangling_edges += 1;
                 report.issues.push(ExportIssue {
                     subject: format!("{src} -[{rel}]-> {dst}"),
-                    reason: "Edge references a node that no longer exists; skipped. This is \
-                             left behind by `MATCH (n:Label) DELETE n`, which does not remove \
-                             incident edges."
-                        .to_string(),
+                    reason: "Edge references a node that no longer exists; skipped.".to_string(),
                 });
                 continue;
             };

--- a/crates/sparrowdb-ontology-core/src/rdf_data.rs
+++ b/crates/sparrowdb-ontology-core/src/rdf_data.rs
@@ -97,7 +97,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use oxrdf::{Literal, NamedNode, Term, Triple};
 use serde_json::{json, Map as JsMap, Value as JsVal};
-use sparrowdb::GraphDb;
+use sparrowdb::{GraphDb, ReadTx};
 use sparrowdb_common::NodeId;
 use sparrowdb_execution::Value as ExecValue;
 use sparrowdb_storage::node_store::Value as StoreValue;
@@ -528,9 +528,10 @@ fn invalid(msg: String) -> SoError {
     SoError::Storage(sparrowdb_common::Error::InvalidArgument(msg))
 }
 
-/// Run a query, treating "unknown label"/"unknown relationship type" as empty.
-fn execute_or_empty(db: &GraphDb, q: &str) -> Result<sparrowdb_execution::QueryResult, SoError> {
-    match db.execute(q) {
+/// Run a query against a pinned snapshot, treating "unknown label"/"unknown
+/// relationship type" as empty.
+fn execute_or_empty(tx: &ReadTx, q: &str) -> Result<sparrowdb_execution::QueryResult, SoError> {
+    match tx.query(q) {
         Ok(r) => Ok(r),
         Err(sparrowdb_common::Error::InvalidArgument(ref msg))
             if msg.contains("unknown label") || msg.contains("unknown relationship type") =>
@@ -546,6 +547,17 @@ fn execute_or_empty(db: &GraphDb, q: &str) -> Result<sparrowdb_execution::QueryR
 /// Triples are keyed by their N-Triples form in a `BTreeMap`, which dedupes
 /// (RDF graphs are sets — a duplicate edge in storage must not become a
 /// duplicate triple) and yields a stable order across runs.
+///
+/// ## Snapshot isolation
+///
+/// The entity pass and the relationship pass each issue one query per
+/// label/relation-type. Without a shared snapshot, a write committed between
+/// those queries could be visible to one pass and not the other — e.g. a node
+/// created after the entity pass scanned its label, then linked by an edge the
+/// relationship pass *does* see. `subject_by_id` would have no entry for that
+/// node, and the edge would be misreported as dangling even though it is live.
+/// Pinning one [`ReadTx`] for the whole traversal makes every query in this
+/// function see the same committed state, so that race cannot occur.
 fn collect_data_triples(
     db: &GraphDb,
     base_iri: &str,
@@ -553,6 +565,7 @@ fn collect_data_triples(
     let base = normalize_base(base_iri);
     let snap = export_schema(db)?;
     let idx = SchemaIndex::build(&snap, &base);
+    let tx = db.begin_read().map_err(SoError::Storage)?;
 
     let mut report = ExportReport::default();
     let mut out: BTreeMap<String, Triple> = BTreeMap::new();
@@ -617,7 +630,7 @@ fn collect_data_triples(
             }
         };
         let q = format!("MATCH (n:{quoted_label}) RETURN id(n), n");
-        let result = execute_or_empty(db, &q)?;
+        let result = execute_or_empty(&tx, &q)?;
         for row in &result.rows {
             let Some(ExecValue::Int64(node_id)) = row.first() else {
                 continue;
@@ -756,7 +769,7 @@ fn collect_data_triples(
             }
         };
         let q = format!("MATCH (a)-[r:{quoted_rel}]->(b) RETURN id(a), id(b)");
-        let result = execute_or_empty(db, &q)?;
+        let result = execute_or_empty(&tx, &q)?;
         for row in &result.rows {
             let (Some(ExecValue::Int64(src)), Some(ExecValue::Int64(dst))) =
                 (row.first(), row.get(1))
@@ -1178,7 +1191,14 @@ pub fn import_data_turtle(
     // entire import over data that was already handled correctly.
     if strategy == ImportStrategy::AutoDeclare {
         let mut added = false;
-        let mut declared_this_pass: HashSet<(String, String)> = HashSet::new();
+        // Maps (class, resolved name) -> the first predicate IRI that
+        // declared it this pass. A second, distinct predicate resolving to
+        // the same name (two IRIs sharing a local name, both falling back to
+        // `local_name`) would otherwise be silently dropped — declared_this_pass
+        // being a plain set of (class, name) can't tell "already declared by
+        // this exact predicate" from "declared by a colliding one", so it
+        // swallows the second predicate with no report entry.
+        let mut declared_this_pass: HashMap<(String, String), String> = HashMap::new();
         for (iri, data) in &subjects {
             let Some(class) = class_of.get(iri) else {
                 continue;
@@ -1194,12 +1214,22 @@ pub fn import_data_turtle(
                     .get(class)
                     .map(|m| m.contains_key(&name))
                     .unwrap_or(false);
-                if declared
-                    || name.starts_with("__so_")
-                    || !declared_this_pass.insert((class.clone(), name.clone()))
-                {
+                if declared || name.starts_with("__so_") {
                     continue;
                 }
+                let key = (class.clone(), name.clone());
+                if let Some(prior_pred) = declared_this_pass.get(&key) {
+                    if prior_pred != pred {
+                        report.warnings.push(format!(
+                            "Subject <{iri}>: predicates <{prior_pred}> and <{pred}> both \
+                             resolve to property name '{name}' on class '{class}'; only \
+                             <{prior_pred}> was auto-declared as its source_iri. Declare \
+                             <{pred}> explicitly with a distinct property name to keep both."
+                        ));
+                    }
+                    continue;
+                }
+                declared_this_pass.insert(key, pred.clone());
                 let ty = xsd_to_type_str(lit.datatype().as_str());
                 match crate::init::add_property(
                     db,
@@ -1282,6 +1312,12 @@ pub fn import_data_turtle(
         let declared = idx.props_by_name.get(class).unwrap_or(&empty);
 
         let mut props: HashMap<String, PropertyValue> = HashMap::new();
+        // Tracks which predicate IRI first populated each resolved property
+        // name, so a second, distinct predicate that resolves to the same
+        // name (e.g. two IRIs sharing a local name, both falling back to
+        // `local_name`) is reported instead of silently overwriting the
+        // first value.
+        let mut name_source: HashMap<String, String> = HashMap::new();
         let mut failed: Option<String> = None;
 
         for (pred, lit) in &data.literals {
@@ -1301,6 +1337,18 @@ pub fn import_data_turtle(
             };
             match literal_to_property_value(&prop.datatype, lit) {
                 Ok(v) => {
+                    if let Some(prior_pred) = name_source.get(&name) {
+                        if prior_pred != pred {
+                            report.warnings.push(format!(
+                                "Subject <{iri}>: predicates <{prior_pred}> and <{pred}> both \
+                                 resolve to property '{name}' on class '{class}'; the value \
+                                 from <{pred}> was kept and <{prior_pred}>'s was discarded. \
+                                 Give one of them an explicit source_iri-registered property to \
+                                 disambiguate."
+                            ));
+                        }
+                    }
+                    name_source.insert(name.clone(), pred.clone());
                     props.insert(name, v);
                 }
                 Err(e) => {

--- a/crates/sparrowdb-ontology-core/src/snapshot.rs
+++ b/crates/sparrowdb-ontology-core/src/snapshot.rs
@@ -321,7 +321,8 @@ fn export_properties(
     let q = format!(
         "MATCH (p:{PROPERTY_LABEL}) \
          RETURN p.symbol_id, p.name, p.datatype, p.required, p.unique, \
-                p.enum_values, p.owner_symbol_id, p.owner_kind, p.created_at"
+                p.enum_values, p.owner_symbol_id, p.owner_kind, p.created_at, \
+                p.description, p.source_iri"
     );
     let result = match db.execute(&q) {
         Ok(r) => r,
@@ -351,6 +352,22 @@ fn export_properties(
         let owner_symbol_id = str_val(&row[6]);
         let owner_kind_str = str_val(&row[7]);
         let created_at = i64_val(&row[8]);
+        let description = row.get(9).and_then(|v| {
+            let s = str_val(v);
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        });
+        let source_iri = row.get(10).and_then(|v| {
+            let s = str_val(v);
+            if s.is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        });
         let owner_name = class_name_by_sid
             .get(&owner_symbol_id)
             .cloned()
@@ -372,6 +389,8 @@ fn export_properties(
             owner_kind,
             created_at,
             owner_name,
+            description,
+            source_iri,
         });
     }
     Ok(out)

--- a/crates/sparrowdb-ontology-core/src/snapshot.rs
+++ b/crates/sparrowdb-ontology-core/src/snapshot.rs
@@ -352,22 +352,8 @@ fn export_properties(
         let owner_symbol_id = str_val(&row[6]);
         let owner_kind_str = str_val(&row[7]);
         let created_at = i64_val(&row[8]);
-        let description = row.get(9).and_then(|v| {
-            let s = str_val(v);
-            if s.is_empty() {
-                None
-            } else {
-                Some(s)
-            }
-        });
-        let source_iri = row.get(10).and_then(|v| {
-            let s = str_val(v);
-            if s.is_empty() {
-                None
-            } else {
-                Some(s)
-            }
-        });
+        let description = row.get(9).and_then(opt_str_val);
+        let source_iri = row.get(10).and_then(opt_str_val);
         let owner_name = class_name_by_sid
             .get(&owner_symbol_id)
             .cloned()

--- a/crates/sparrowdb-ontology-core/src/snapshot.rs
+++ b/crates/sparrowdb-ontology-core/src/snapshot.rs
@@ -140,7 +140,7 @@ fn status_to_str(s: &SymbolStatus) -> &'static str {
     }
 }
 
-fn property_type_from_str(s: &str) -> PropertyType {
+pub(crate) fn property_type_from_str(s: &str) -> PropertyType {
     match s {
         "int64" => PropertyType::Int64,
         "float64" => PropertyType::Float64,

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -29,8 +29,9 @@ use sparrowdb_storage::node_store::Value as StoreValue;
 
 use crate::error::SoError;
 use crate::init::{add_alias, add_property, define_subclass};
-use crate::model::{AliasKind, SymbolStatus};
+use crate::model::{AliasKind, PropertyType, SymbolStatus};
 use crate::namespace::{CLASS_LABEL, DOMAIN_REL, RANGE_REL, RELATION_LABEL};
+use crate::snapshot::export_schema;
 
 // ── IRI constants ─────────────────────────────────────────────────────────────
 
@@ -88,6 +89,9 @@ pub struct ImportSummary {
     pub aliases_imported: usize,
     pub properties_imported: usize,
     pub warnings: Vec<String>,
+    /// Names of `owl:DatatypeProperty` terms that were skipped because they
+    /// had no resolvable `rdfs:domain`.
+    pub skipped_no_domain_properties: Vec<String>,
 }
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -297,6 +301,7 @@ pub fn import_turtle(
     let mut subclasses_imported: usize = 0;
     let mut aliases_imported: usize = 0;
     let mut properties_imported: usize = 0;
+    let mut skipped_no_domain_properties: Vec<String> = Vec::new();
 
     // 4a. Import classes
     for iri in &class_iris {
@@ -375,6 +380,7 @@ pub fn import_turtle(
 
         if domain_names.is_empty() {
             warnings.push(format!("data property '{name}': no rdfs:domain — skipped"));
+            skipped_no_domain_properties.push(name.clone());
             continue;
         }
 
@@ -390,7 +396,23 @@ pub fn import_turtle(
             match add_property(db, owner, &name, type_str, false, false, None) {
                 Ok(_) => properties_imported += 1,
                 Err(SoError::DuplicateProperty { .. }) => {
-                    // Idempotent — already declared
+                    // Check for type drift: warn if the existing property has a different type
+                    if let Ok(snap) = export_schema(db) {
+                        if let Some(existing) = snap
+                            .properties
+                            .iter()
+                            .find(|p| p.owner_name == *owner && p.name == name)
+                        {
+                            let incoming_type = xsd_str_to_property_type(type_str);
+                            if existing.datatype != incoming_type {
+                                warnings.push(format!(
+                                    "data property '{name}' on '{owner}': type conflict \
+                                     — existing={:?}, incoming={type_str}",
+                                    existing.datatype
+                                ));
+                            }
+                        }
+                    }
                 }
                 Err(e) => warnings.push(format!("data property '{name}' on '{owner}': {e}")),
             }
@@ -433,10 +455,25 @@ pub fn import_turtle(
         aliases_imported,
         properties_imported,
         warnings,
+        skipped_no_domain_properties,
     })
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Convert a Sparrow type string (as returned by `xsd_to_type_str`) to a `PropertyType` variant.
+///
+/// Mirrors the mapping in `init::parse_property_type_str`.
+fn xsd_str_to_property_type(s: &str) -> PropertyType {
+    match s {
+        "int64" => PropertyType::Int64,
+        "float64" => PropertyType::Float64,
+        "bool" => PropertyType::Bool,
+        "date" => PropertyType::Date,
+        "variant" => PropertyType::Variant,
+        _ => PropertyType::String,
+    }
+}
 
 /// Map an XSD datatype IRI to a Sparrow property type string.
 fn xsd_to_type_str(xsd_iri: &str) -> &'static str {

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -29,6 +29,7 @@ use sparrowdb_storage::node_store::Value as StoreValue;
 
 use crate::error::SoError;
 use crate::init::{add_alias, add_property, define_subclass};
+use crate::resolution::resolve;
 use crate::model::{AliasKind, PropertyType, SymbolStatus};
 use crate::namespace::{CLASS_LABEL, DOMAIN_REL, RANGE_REL, RELATION_LABEL};
 use crate::snapshot::export_schema;
@@ -308,6 +309,19 @@ pub fn import_turtle(
     let mut skipped_no_domain_properties: Vec<String> = Vec::new();
     let mut dropped_property_comments: Vec<(String, String)> = Vec::new();
 
+    // Pre-build (owner_name, prop_name) → PropertyType map for type-drift checks on
+    // DuplicateProperty.  Built once here to avoid re-querying the schema on every
+    // duplicate hit.  Storage failures are fatal and propagated immediately.
+    let existing_props: HashMap<(String, String), PropertyType> = if data_prop_iris.is_empty() {
+        HashMap::new()
+    } else {
+        export_schema(db)?
+            .properties
+            .into_iter()
+            .map(|p| ((p.owner_name, p.name), p.datatype))
+            .collect()
+    };
+
     // 4a. Import classes
     for iri in &class_iris {
         let name = iri_to_name
@@ -386,7 +400,18 @@ pub fn import_turtle(
             .get(iri)
             .map(|v| {
                 v.iter()
-                    .filter_map(|d_iri| iri_to_name.get(d_iri).cloned())
+                    .filter_map(|d_iri| {
+                        // Prefer name from the current import fragment; fall back to
+                        // resolving the local name against the DB so that DatatypeProperty
+                        // declarations that reference a class already in the DB (but not
+                        // re-typed in this Turtle) are not incorrectly skipped.
+                        iri_to_name.get(d_iri).cloned().or_else(|| {
+                            let candidate = local_name(d_iri);
+                            resolve(db, &candidate, AliasKind::Class)
+                                .ok()
+                                .map(|_| candidate)
+                        })
+                    })
                     .collect()
             })
             .unwrap_or_default();
@@ -397,10 +422,17 @@ pub fn import_turtle(
             continue;
         }
 
-        // Resolve XSD range → Sparrow property type
+        // Resolve XSD range → Sparrow property type.
+        // Prefer the first XSD-namespace range IRI; fall back to the first range of
+        // any kind so non-XSD custom ranges still produce "string" rather than being
+        // silently skipped when an XSD range appears later in the list.
         let type_str = ranges
             .get(iri)
-            .and_then(|v| v.first())
+            .and_then(|v| {
+                v.iter()
+                    .find(|r| r.starts_with("http://www.w3.org/2001/XMLSchema#"))
+                    .or_else(|| v.first())
+            })
             .map(|xsd_iri| xsd_to_type_str(xsd_iri))
             .unwrap_or("string");
 
@@ -417,21 +449,15 @@ pub fn import_turtle(
             match add_property(db, owner, &name, type_str, false, false, None) {
                 Ok(_) => properties_imported += 1,
                 Err(SoError::DuplicateProperty { .. }) => {
-                    // Check for type drift: warn if the existing property has a different type
-                    if let Ok(snap) = export_schema(db) {
-                        if let Some(existing) = snap
-                            .properties
-                            .iter()
-                            .find(|p| p.owner_name == *owner && p.name == name)
-                        {
-                            let incoming_type = xsd_str_to_property_type(type_str);
-                            if existing.datatype != incoming_type {
-                                warnings.push(format!(
-                                    "data property '{name}' on '{owner}': type conflict \
-                                     — existing={:?}, incoming={type_str}",
-                                    existing.datatype
-                                ));
-                            }
+                    // Check for type drift using the pre-built cache.
+                    let incoming_type = xsd_str_to_property_type(type_str);
+                    if let Some(existing_type) = existing_props.get(&(owner.clone(), name.clone()))
+                    {
+                        if existing_type != &incoming_type {
+                            warnings.push(format!(
+                                "data property '{name}' on '{owner}': type conflict \
+                                 — existing={existing_type:?}, incoming={type_str}"
+                            ));
                         }
                     }
                 }

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -307,7 +307,9 @@ pub fn import_turtle(
     // Pre-build (owner_name, prop_name) → PropertyType map for type-drift checks on
     // DuplicateProperty.  Built once here to avoid re-querying the schema on every
     // duplicate hit.  Storage failures are fatal and propagated immediately.
-    let existing_props: HashMap<(String, String), PropertyType> = if data_prop_iris.is_empty() {
+    // Kept mutable so successful same-batch insertions are visible to subsequent
+    // duplicate checks within the same import run.
+    let mut existing_props: HashMap<(String, String), PropertyType> = if data_prop_iris.is_empty() {
         HashMap::new()
     } else {
         export_schema(db)?
@@ -437,6 +439,9 @@ pub fn import_turtle(
             .map(String::as_str);
         let prop_iri = Some(iri.as_str());
 
+        // Resolve incoming type once — used in both the success and duplicate paths.
+        let incoming_type = crate::init::parse_property_type_str(type_str);
+
         // Import property on each domain class
         for owner in &domain_names {
             match add_property(
@@ -450,10 +455,13 @@ pub fn import_turtle(
                 prop_description,
                 prop_iri,
             ) {
-                Ok(_) => properties_imported += 1,
+                Ok(_) => {
+                    properties_imported += 1;
+                    // Update cache so subsequent same-batch duplicates see this insertion.
+                    existing_props.insert((owner.clone(), name.clone()), incoming_type.clone());
+                }
                 Err(SoError::DuplicateProperty { .. }) => {
-                    // Check for type drift using the pre-built cache.
-                    let incoming_type = crate::init::parse_property_type_str(type_str);
+                    // Check for type drift using the cache (pre-import DB state + same-batch inserts).
                     if let Some(existing_type) = existing_props.get(&(owner.clone(), name.clone()))
                     {
                         if existing_type != &incoming_type {

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -92,6 +92,10 @@ pub struct ImportSummary {
     /// Names of `owl:DatatypeProperty` terms that were skipped because they
     /// had no resolvable `rdfs:domain`.
     pub skipped_no_domain_properties: Vec<String>,
+    /// `(property_name, comment)` pairs for `owl:DatatypeProperty` terms whose
+    /// `rdfs:comment` could not be persisted because `add_property` has no
+    /// description parameter.  Callers may surface or store these separately.
+    pub dropped_property_comments: Vec<(String, String)>,
 }
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -302,6 +306,7 @@ pub fn import_turtle(
     let mut aliases_imported: usize = 0;
     let mut properties_imported: usize = 0;
     let mut skipped_no_domain_properties: Vec<String> = Vec::new();
+    let mut dropped_property_comments: Vec<(String, String)> = Vec::new();
 
     // 4a. Import classes
     for iri in &class_iris {
@@ -399,11 +404,13 @@ pub fn import_turtle(
             .map(|xsd_iri| xsd_to_type_str(xsd_iri))
             .unwrap_or("string");
 
-        // rdfs:comment for DatatypeProperty is intentionally not persisted: the
-        // add_property API has no description parameter and the OntologyProperty model
-        // has no description field.  Silently dropping it is correct — the comment is
-        // metadata on the OWL property IRI itself, not on the Sparrow class property.
-        // If add_property ever gains a description field this should be plumbed through.
+        // Carry rdfs:comment into ImportSummary for callers to handle.
+        // add_property has no description parameter today; tracked in issue #39.
+        if let Some(comment) = comments.get(iri) {
+            if !comment.is_empty() {
+                dropped_property_comments.push((name.clone(), comment.clone()));
+            }
+        }
 
         // Import property on each domain class
         for owner in &domain_names {
@@ -470,6 +477,7 @@ pub fn import_turtle(
         properties_imported,
         warnings,
         skipped_no_domain_properties,
+        dropped_property_comments,
     })
 }
 

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -8,12 +8,14 @@
 //! | Turtle construct              | Maps to                              |
 //! |-------------------------------|--------------------------------------|
 //! | `owl:Class`, `rdfs:Class`, `schema:Class` via `rdf:type` | `__SO_Class` node |
-//! | `owl:ObjectProperty`, `owl:DatatypeProperty` via `rdf:type` | `__SO_Relation` node |
+//! | `owl:ObjectProperty` via `rdf:type` | `__SO_Relation` node |
+//! | `owl:DatatypeProperty` via `rdf:type` | `add_property` on the domain class |
 //! | `rdfs:subClassOf`             | `__SO_SUBCLASS_OF` edge              |
 //! | `rdfs:label`                  | `name` property (prefer `@en`)       |
 //! | `rdfs:comment`                | `description` property               |
-//! | `rdfs:domain`                 | `__SO_DOMAIN` edge (subject to strategy) |
-//! | `rdfs:range`                  | `__SO_RANGE` edge (subject to strategy) |
+//! | `rdfs:domain`                 | `__SO_DOMAIN` edge (subject to strategy) OR `add_property` owner |
+//! | `rdfs:range` (class IRI)      | `__SO_RANGE` edge (subject to strategy) |
+//! | `rdfs:range` (XSD datatype)   | property type for `owl:DatatypeProperty` |
 //! | `schema:domainIncludes`       | `__SO_DOMAIN` edge (subject to strategy) |
 //! | `schema:rangeIncludes`        | `__SO_RANGE` edge (subject to strategy) |
 //! | `skos:altLabel`               | `__SO_Alias` node                    |
@@ -26,7 +28,7 @@ use sparrowdb_common::NodeId;
 use sparrowdb_storage::node_store::Value as StoreValue;
 
 use crate::error::SoError;
-use crate::init::{add_alias, define_subclass};
+use crate::init::{add_alias, add_property, define_subclass};
 use crate::model::{AliasKind, SymbolStatus};
 use crate::namespace::{CLASS_LABEL, DOMAIN_REL, RANGE_REL, RELATION_LABEL};
 
@@ -84,6 +86,7 @@ pub struct ImportSummary {
     pub relations_imported: usize,
     pub subclasses_imported: usize,
     pub aliases_imported: usize,
+    pub properties_imported: usize,
     pub warnings: Vec<String>,
 }
 
@@ -104,7 +107,8 @@ pub fn import_turtle(
     // ── Step 1: Parse all triples into in-memory maps ─────────────────────────
 
     let mut class_iris: HashSet<String> = HashSet::new();
-    let mut prop_iris: HashSet<String> = HashSet::new();
+    let mut obj_prop_iris: HashSet<String> = HashSet::new();
+    let mut data_prop_iris: HashSet<String> = HashSet::new();
 
     // IRI → preferred label  (tracking language preference separately)
     let mut labels_en: HashMap<String, String> = HashMap::new();
@@ -162,8 +166,11 @@ pub fn import_turtle(
                         t if t == OWL_CLASS || t == RDFS_CLASS || t == SCHEMA_CLASS => {
                             class_iris.insert(subject_iri);
                         }
-                        t if t == OWL_OBJ_PROP || t == OWL_DATA_PROP => {
-                            prop_iris.insert(subject_iri);
+                        t if t == OWL_OBJ_PROP => {
+                            obj_prop_iris.insert(subject_iri);
+                        }
+                        t if t == OWL_DATA_PROP => {
+                            data_prop_iris.insert(subject_iri);
                         }
                         _ => {}
                     }
@@ -257,7 +264,11 @@ pub fn import_turtle(
     // ── Step 2: Build consolidated label map ──────────────────────────────────
 
     // Merge all IRIs seen (classes + props + anything with a label)
-    let all_iris: HashSet<&String> = class_iris.iter().chain(prop_iris.iter()).collect();
+    let all_iris: HashSet<&String> = class_iris
+        .iter()
+        .chain(obj_prop_iris.iter())
+        .chain(data_prop_iris.iter())
+        .collect();
     let mut labels: HashMap<String, String> = HashMap::new();
     for iri in &all_iris {
         let label = labels_en
@@ -285,6 +296,7 @@ pub fn import_turtle(
     let mut relations_imported: usize = 0;
     let mut subclasses_imported: usize = 0;
     let mut aliases_imported: usize = 0;
+    let mut properties_imported: usize = 0;
 
     // 4a. Import classes
     for iri in &class_iris {
@@ -329,8 +341,8 @@ pub fn import_turtle(
         }
     }
 
-    // 4c. Import relations
-    for iri in &prop_iris {
+    // 4c. Import relations (owl:ObjectProperty)
+    for iri in &obj_prop_iris {
         let name = iri_to_name
             .get(iri)
             .cloned()
@@ -344,7 +356,48 @@ pub fn import_turtle(
         }
     }
 
-    // 4d. Import aliases (skos:altLabel)
+    // 4d. Import data properties (owl:DatatypeProperty → add_property)
+    for iri in &data_prop_iris {
+        let name = iri_to_name
+            .get(iri)
+            .cloned()
+            .unwrap_or_else(|| local_name(iri));
+
+        // Collect all resolvable domain classes (rdfs:domain or schema:domainIncludes)
+        let domain_names: Vec<String> = domains
+            .get(iri)
+            .map(|v| {
+                v.iter()
+                    .filter_map(|d_iri| iri_to_name.get(d_iri).cloned())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if domain_names.is_empty() {
+            warnings.push(format!("data property '{name}': no rdfs:domain — skipped"));
+            continue;
+        }
+
+        // Resolve XSD range → Sparrow property type
+        let type_str = ranges
+            .get(iri)
+            .and_then(|v| v.first())
+            .map(|xsd_iri| xsd_to_type_str(xsd_iri))
+            .unwrap_or("string");
+
+        // Import property on each domain class
+        for owner in &domain_names {
+            match add_property(db, owner, &name, type_str, false, false, None) {
+                Ok(_) => properties_imported += 1,
+                Err(SoError::DuplicateProperty { .. }) => {
+                    // Idempotent — already declared
+                }
+                Err(e) => warnings.push(format!("data property '{name}' on '{owner}': {e}")),
+            }
+        }
+    }
+
+    // 4e. Import aliases (skos:altLabel)
     for (iri, alts) in &alt_labels {
         let name = match iri_to_name.get(iri) {
             Some(n) => n.clone(),
@@ -352,8 +405,11 @@ pub fn import_turtle(
         };
         let kind = if class_iris.contains(iri) {
             AliasKind::Class
-        } else {
+        } else if obj_prop_iris.contains(iri) {
             AliasKind::Relation
+        } else {
+            // data properties don't have an alias kind — skip
+            continue;
         };
         for alt in alts {
             match add_alias(db, alt, kind.clone(), &name) {
@@ -375,11 +431,38 @@ pub fn import_turtle(
         relations_imported,
         subclasses_imported,
         aliases_imported,
+        properties_imported,
         warnings,
     })
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Map an XSD datatype IRI to a Sparrow property type string.
+fn xsd_to_type_str(xsd_iri: &str) -> &'static str {
+    match xsd_iri {
+        i if i.ends_with("#integer")
+            || i.ends_with("#int")
+            || i.ends_with("#long")
+            || i.ends_with("#short")
+            || i.ends_with("#byte")
+            || i.ends_with("#nonNegativeInteger")
+            || i.ends_with("#positiveInteger")
+            || i.ends_with("#negativeInteger")
+            || i.ends_with("#nonPositiveInteger")
+            || i.ends_with("#unsignedLong")
+            || i.ends_with("#unsignedInt") =>
+        {
+            "int64"
+        }
+        i if i.ends_with("#decimal") || i.ends_with("#float") || i.ends_with("#double") => {
+            "float64"
+        }
+        i if i.ends_with("#boolean") => "bool",
+        i if i.ends_with("#date") || i.ends_with("#dateTime") || i.ends_with("#time") => "date",
+        _ => "string",
+    }
+}
 
 /// Extract the local name from an IRI (everything after the last `#` or `/`).
 fn local_name(iri: &str) -> String {

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -368,7 +368,15 @@ pub fn import_turtle(
             .cloned()
             .unwrap_or_else(|| local_name(iri));
 
-        // Collect all resolvable domain classes (rdfs:domain or schema:domainIncludes)
+        // Collect all resolvable domain classes (rdfs:domain or schema:domainIncludes).
+        //
+        // NOTE: DatatypeProperty intentionally does NOT apply resolve_domain_range / strategy
+        // here.  Unlike ObjectProperty (which maps to a graph edge and can only have one
+        // domain endpoint), a DatatypeProperty maps to add_property which attaches a scalar
+        // field to a class node — it is safe and correct to add the same property to every
+        // declared domain class.  The domain_range_strategy controls edge semantics only.
+        // Tests `multi_domain_includes_drops_domain_unconstrained` and
+        // `first_only_strategy_keeps_domain` both document this fanout behaviour.
         let domain_names: Vec<String> = domains
             .get(iri)
             .map(|v| {
@@ -390,6 +398,12 @@ pub fn import_turtle(
             .and_then(|v| v.first())
             .map(|xsd_iri| xsd_to_type_str(xsd_iri))
             .unwrap_or("string");
+
+        // rdfs:comment for DatatypeProperty is intentionally not persisted: the
+        // add_property API has no description parameter and the OntologyProperty model
+        // has no description field.  Silently dropping it is correct — the comment is
+        // metadata on the OWL property IRI itself, not on the Sparrow class property.
+        // If add_property ever gains a description field this should be plumbed through.
 
         // Import property on each domain class
         for owner in &domain_names {
@@ -476,27 +490,25 @@ fn xsd_str_to_property_type(s: &str) -> PropertyType {
 }
 
 /// Map an XSD datatype IRI to a Sparrow property type string.
+///
+/// Only IRIs whose namespace is exactly `http://www.w3.org/2001/XMLSchema#` are
+/// considered XSD; anything else falls through to `"string"` to avoid false
+/// matches on custom IRIs that happen to share a suffix (e.g. `example.com/ns#int`).
 fn xsd_to_type_str(xsd_iri: &str) -> &'static str {
-    match xsd_iri {
-        i if i.ends_with("#integer")
-            || i.ends_with("#int")
-            || i.ends_with("#long")
-            || i.ends_with("#short")
-            || i.ends_with("#byte")
-            || i.ends_with("#nonNegativeInteger")
-            || i.ends_with("#positiveInteger")
-            || i.ends_with("#negativeInteger")
-            || i.ends_with("#nonPositiveInteger")
-            || i.ends_with("#unsignedLong")
-            || i.ends_with("#unsignedInt") =>
-        {
-            "int64"
-        }
-        i if i.ends_with("#decimal") || i.ends_with("#float") || i.ends_with("#double") => {
-            "float64"
-        }
-        i if i.ends_with("#boolean") => "bool",
-        i if i.ends_with("#date") || i.ends_with("#dateTime") || i.ends_with("#time") => "date",
+    const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
+    let local = match xsd_iri.strip_prefix(XSD_NS) {
+        Some(l) => l,
+        None => return "string",
+    };
+    match local {
+        "integer" | "int" | "long" | "short" | "byte" | "nonNegativeInteger"
+        | "positiveInteger" | "negativeInteger" | "nonPositiveInteger" | "unsignedLong"
+        | "unsignedInt" | "unsignedShort" | "unsignedByte" => "int64",
+        "decimal" | "float" | "double" => "float64",
+        "boolean" => "bool",
+        // xsd:date and xsd:dateTime carry a calendar date component → "date".
+        // xsd:time (HH:MM:SS only, no date) has no Sparrow Date equivalent → "string".
+        "date" | "dateTime" => "date",
         _ => "string",
     }
 }

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -93,10 +93,6 @@ pub struct ImportSummary {
     /// Names of `owl:DatatypeProperty` terms that were skipped because they
     /// had no resolvable `rdfs:domain`.
     pub skipped_no_domain_properties: Vec<String>,
-    /// `(property_name, comment)` pairs for `owl:DatatypeProperty` terms whose
-    /// `rdfs:comment` could not be persisted because `add_property` has no
-    /// description parameter.  Callers may surface or store these separately.
-    pub dropped_property_comments: Vec<(String, String)>,
 }
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -307,7 +303,6 @@ pub fn import_turtle(
     let mut aliases_imported: usize = 0;
     let mut properties_imported: usize = 0;
     let mut skipped_no_domain_properties: Vec<String> = Vec::new();
-    let mut dropped_property_comments: Vec<(String, String)> = Vec::new();
 
     // Pre-build (owner_name, prop_name) → PropertyType map for type-drift checks on
     // DuplicateProperty.  Built once here to avoid re-querying the schema on every
@@ -436,17 +431,25 @@ pub fn import_turtle(
             .map(|xsd_iri| xsd_to_type_str(xsd_iri))
             .unwrap_or("string");
 
-        // Carry rdfs:comment into ImportSummary for callers to handle.
-        // add_property has no description parameter today; tracked in issue #39.
-        if let Some(comment) = comments.get(iri) {
-            if !comment.is_empty() {
-                dropped_property_comments.push((name.clone(), comment.clone()));
-            }
-        }
+        let prop_description = comments
+            .get(iri)
+            .filter(|s| !s.is_empty())
+            .map(String::as_str);
+        let prop_iri = Some(iri.as_str());
 
         // Import property on each domain class
         for owner in &domain_names {
-            match add_property(db, owner, &name, type_str, false, false, None) {
+            match add_property(
+                db,
+                owner,
+                &name,
+                type_str,
+                false,
+                false,
+                None,
+                prop_description,
+                prop_iri,
+            ) {
                 Ok(_) => properties_imported += 1,
                 Err(SoError::DuplicateProperty { .. }) => {
                     // Check for type drift using the pre-built cache.
@@ -503,7 +506,6 @@ pub fn import_turtle(
         properties_imported,
         warnings,
         skipped_no_domain_properties,
-        dropped_property_comments,
     })
 }
 

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -453,7 +453,7 @@ pub fn import_turtle(
                 Ok(_) => properties_imported += 1,
                 Err(SoError::DuplicateProperty { .. }) => {
                     // Check for type drift using the pre-built cache.
-                    let incoming_type = xsd_str_to_property_type(type_str);
+                    let incoming_type = crate::init::parse_property_type_str(type_str);
                     if let Some(existing_type) = existing_props.get(&(owner.clone(), name.clone()))
                     {
                         if existing_type != &incoming_type {
@@ -510,20 +510,6 @@ pub fn import_turtle(
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Convert a Sparrow type string (as returned by `xsd_to_type_str`) to a `PropertyType` variant.
-///
-/// Mirrors the mapping in `init::parse_property_type_str`.
-fn xsd_str_to_property_type(s: &str) -> PropertyType {
-    match s {
-        "int64" => PropertyType::Int64,
-        "float64" => PropertyType::Float64,
-        "bool" => PropertyType::Bool,
-        "date" => PropertyType::Date,
-        "variant" => PropertyType::Variant,
-        _ => PropertyType::String,
-    }
-}
 
 /// Map an XSD datatype IRI to a Sparrow property type string.
 ///

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -29,9 +29,9 @@ use sparrowdb_storage::node_store::Value as StoreValue;
 
 use crate::error::SoError;
 use crate::init::{add_alias, add_property, define_subclass};
-use crate::resolution::resolve;
 use crate::model::{AliasKind, PropertyType, SymbolStatus};
 use crate::namespace::{CLASS_LABEL, DOMAIN_REL, RANGE_REL, RELATION_LABEL};
+use crate::resolution::resolve;
 use crate::snapshot::export_schema;
 
 // ── IRI constants ─────────────────────────────────────────────────────────────

--- a/crates/sparrowdb-ontology-core/src/turtle_import.rs
+++ b/crates/sparrowdb-ontology-core/src/turtle_import.rs
@@ -524,7 +524,7 @@ pub fn import_turtle(
 /// Only IRIs whose namespace is exactly `http://www.w3.org/2001/XMLSchema#` are
 /// considered XSD; anything else falls through to `"string"` to avoid false
 /// matches on custom IRIs that happen to share a suffix (e.g. `example.com/ns#int`).
-fn xsd_to_type_str(xsd_iri: &str) -> &'static str {
+pub(crate) fn xsd_to_type_str(xsd_iri: &str) -> &'static str {
     const XSD_NS: &str = "http://www.w3.org/2001/XMLSchema#";
     let local = match xsd_iri.strip_prefix(XSD_NS) {
         Some(l) => l,
@@ -607,7 +607,7 @@ fn kv(pairs: &[(&str, StoreValue)]) -> std::collections::HashMap<String, StoreVa
 ///
 /// Uses `merge_node` which is idempotent: if a node with the same `symbol_id`
 /// already exists it is updated; no duplicate is created.
-fn write_class_node(
+pub(crate) fn write_class_node(
     db: &GraphDb,
     name: &str,
     description: &str,
@@ -634,7 +634,7 @@ fn write_class_node(
 
 /// Write (or overwrite) a `__SO_Relation` node. Optionally creates
 /// `__SO_DOMAIN` and `__SO_RANGE` edges if the target class nodes exist.
-fn write_relation_node(
+pub(crate) fn write_relation_node(
     db: &GraphDb,
     name: &str,
     description: &str,

--- a/crates/sparrowdb-ontology-core/src/validation.rs
+++ b/crates/sparrowdb-ontology-core/src/validation.rs
@@ -390,6 +390,8 @@ impl<'a> ValidationContext<'a> {
                 owner_kind: crate::model::OwnerKind::Class,
                 created_at: 0,
                 owner_name: String::new(),
+                description: None,
+                source_iri: None,
             });
         }
         Ok(props)

--- a/crates/sparrowdb-ontology-core/src/validation.rs
+++ b/crates/sparrowdb-ontology-core/src/validation.rs
@@ -163,7 +163,7 @@ pub fn validate(db: &GraphDb) -> Result<ValidationReport, SoError> {
 }
 
 /// Provenance properties that callers ARE allowed to set.
-const ALLOWED_SO_KEYS: &[&str] = &["__so_source_label", "__so_source_rel"];
+const ALLOWED_SO_KEYS: &[&str] = &["__so_source_label", "__so_source_rel", "__so_iri"];
 
 // ── ValidationContext ─────────────────────────────────────────────────────────
 

--- a/crates/sparrowdb-ontology-mcp/src/main.rs
+++ b/crates/sparrowdb-ontology-mcp/src/main.rs
@@ -565,6 +565,40 @@ fn tool_list() -> Value {
                     },
                     "required": ["turtle"]
                 }
+            },
+            {
+                "name": "export_data_turtle",
+                "description": "Export the instance data (entities and relationships, not the schema) as Turtle. Each entity becomes a subject IRI, rdf:type comes from its ontology class, properties become typed literals with XSD datatypes derived from the ontology, and relationships become object properties. Returns the Turtle plus a report of anything that could not be represented (undeclared columns, unknown labels, dangling edges).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "base_iri": {"type": "string", "description": "Namespace entity IRIs are minted under, e.g. 'https://example.org/kb'. Entities that carry a stored IRI from a previous import keep it."}
+                    },
+                    "required": ["base_iri"]
+                }
+            },
+            {
+                "name": "export_data_json_ld",
+                "description": "Export the instance data as JSON-LD 1.1. Same graph as export_data_turtle, with an @context derived from the ontology: relations become @id terms and typed properties carry XSD datatype coercions.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "base_iri": {"type": "string", "description": "Namespace entity IRIs are minted under, e.g. 'https://example.org/kb'."}
+                    },
+                    "required": ["base_iri"]
+                }
+            },
+            {
+                "name": "import_data_turtle",
+                "description": "Import instance data from Turtle. Subjects whose rdf:type matches a known class become entities via the validated write path; the subject IRI is persisted so a later export reproduces it. Nothing is dropped silently — every skipped subject is reported with its IRI and an actionable reason. Blank nodes are flagged and skipped.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "turtle": {"type": "string", "description": "The Turtle instance-data text to import"},
+                        "strategy": {"type": "string", "enum": ["strict", "auto_declare"], "description": "'strict' (default) rejects unknown classes, relations, and properties and reports them. 'auto_declare' declares them on the fly, deriving property types from XSD datatypes and relation domain/range from the observed subject and object classes.", "default": "strict"}
+                    },
+                    "required": ["turtle"]
+                }
             }
         ]
     })

--- a/crates/sparrowdb-ontology-mcp/src/tools/data.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/data.rs
@@ -240,8 +240,106 @@ pub fn dispatch(db: &GraphDb, name: &str, params: Option<Value>) -> Result<Value
         "find_entities" => find_entities(db, params),
         "explain_symbol" => explain_symbol(db, params),
         "validate" => validate(db, params),
+        "export_data_turtle" => export_data_turtle(db, params),
+        "export_data_json_ld" => export_data_json_ld(db, params),
+        "import_data_turtle" => import_data_turtle(db, params),
         _ => Err(mcp_error(-32601, "Method not found", json!({"tool": name}))),
     }
+}
+
+// ── Instance-data RDF tools (WS1) ─────────────────────────────────────────────
+//
+// Thin wrappers over sparrowdb_ontology_core::rdf_data. All logic lives in core;
+// these only marshal params and format the response.
+
+fn require_base_iri(args: &Value) -> Result<String, Value> {
+    args["base_iri"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            mcp_error(
+                -32602,
+                "Missing required param: base_iri",
+                json!({"detail": "base_iri is the namespace entity IRIs are minted under, \
+                                  e.g. 'https://example.org/kb'."}),
+            )
+        })
+}
+
+pub fn export_data_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, Value> {
+    let args = params.unwrap_or(json!({}));
+    let base_iri = require_base_iri(&args)?;
+
+    let (turtle, report) = sparrowdb_ontology_core::export_data_with_report(db, &base_iri)
+        .map_err(|e| so_error_to_mcp_error(-32603, "Data export failed", &e))?;
+
+    Ok(json!({
+        "content": [
+            {"type": "text", "text": turtle},
+            {"type": "text", "text": serde_json::to_string(&json!({
+                "entities_exported": report.entities_exported,
+                "relationships_exported": report.relationships_exported,
+                "triples_emitted": report.triples_emitted,
+                "orphan_properties": report.orphan_properties,
+                "orphan_labels": report.orphan_labels,
+                "orphan_relation_types": report.orphan_relation_types,
+                "dangling_edges": report.dangling_edges,
+                "issues": report.issues,
+            })).unwrap_or_default()}
+        ]
+    }))
+}
+
+pub fn export_data_json_ld(db: &GraphDb, params: Option<Value>) -> Result<Value, Value> {
+    let args = params.unwrap_or(json!({}));
+    let base_iri = require_base_iri(&args)?;
+
+    let doc = sparrowdb_ontology_core::export_data_json_ld(db, &base_iri)
+        .map_err(|e| so_error_to_mcp_error(-32603, "Data export failed", &e))?;
+
+    let text = serde_json::to_string_pretty(&doc).map_err(|e| {
+        mcp_error(
+            -32603,
+            "serialization_error",
+            json!({"detail": e.to_string()}),
+        )
+    })?;
+    Ok(json!({ "content": [{"type": "text", "text": text}] }))
+}
+
+pub fn import_data_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, Value> {
+    let args = params.unwrap_or(json!({}));
+
+    let turtle = args["turtle"]
+        .as_str()
+        .ok_or_else(|| mcp_error(-32602, "Missing required param: turtle", json!({})))?;
+
+    let strategy = match args["strategy"].as_str().unwrap_or("strict") {
+        "auto_declare" | "auto-declare" | "AutoDeclare" => {
+            sparrowdb_ontology_core::ImportStrategy::AutoDeclare
+        }
+        "strict" | "Strict" => sparrowdb_ontology_core::ImportStrategy::Strict,
+        other => {
+            return Err(mcp_error(
+                -32602,
+                "Invalid strategy",
+                json!({"detail": format!(
+                    "strategy must be 'strict' or 'auto_declare', got '{other}'"
+                )}),
+            ))
+        }
+    };
+
+    let report = sparrowdb_ontology_core::import_data_turtle(db, turtle, strategy)
+        .map_err(|e| so_error_to_mcp_error(-32603, "Data import failed", &e))?;
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string(&report).unwrap_or_default()
+        }]
+    }))
 }
 
 // ── create_entity ─────────────────────────────────────────────────────────────

--- a/crates/sparrowdb-ontology-mcp/src/tools/data.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/data.rs
@@ -11,7 +11,7 @@ use sparrowdb_ontology_core::namespace::{
     ALIAS_LABEL, ALIAS_OF_REL, CLASS_LABEL, DOMAIN_REL, HAS_PROPERTY_REL, PROPERTY_LABEL,
     RANGE_REL, RELATION_LABEL, SUBCLASS_OF_REL, SUBPROPERTY_OF_REL,
 };
-use sparrowdb_ontology_core::{resolve, ValidationContext};
+use sparrowdb_ontology_core::{property_value_to_store, resolve, ValidationContext};
 use sparrowdb_storage::node_store::Value as StoreValue;
 
 use crate::error::{mcp_error, so_error_to_mcp, so_error_to_mcp_error};
@@ -181,21 +181,6 @@ fn json_to_property_value(v: &Value) -> PropertyValue {
     }
 }
 
-// ── PropertyValue → StoreValue ────────────────────────────────────────────────
-
-fn property_value_to_store(v: &PropertyValue) -> Option<StoreValue> {
-    match v {
-        PropertyValue::String(s) => Some(StoreValue::Bytes(s.as_bytes().to_vec())),
-        PropertyValue::Int64(n) => Some(StoreValue::Int64(*n)),
-        PropertyValue::Float64(f) => {
-            // Store floats as bytes (string representation) since StoreValue may not have Float64
-            Some(StoreValue::Bytes(f.to_string().as_bytes().to_vec()))
-        }
-        PropertyValue::Bool(b) => Some(StoreValue::Int64(if *b { 1 } else { 0 })),
-        PropertyValue::Null => None,
-    }
-}
-
 fn props_to_store(props: &HashMap<String, PropertyValue>) -> HashMap<String, StoreValue> {
     props
         .iter()
@@ -274,19 +259,13 @@ pub fn export_data_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
     let (turtle, report) = sparrowdb_ontology_core::export_data_with_report(db, &base_iri)
         .map_err(|e| so_error_to_mcp_error(-32603, "Data export failed", &e))?;
 
+    // Serialize the whole ExportReport rather than re-listing fields here —
+    // a manually maintained subset silently falls behind whenever the report
+    // grows a field (this is exactly how it missed `unrepresentable_iris`).
     Ok(json!({
         "content": [
             {"type": "text", "text": turtle},
-            {"type": "text", "text": serde_json::to_string(&json!({
-                "entities_exported": report.entities_exported,
-                "relationships_exported": report.relationships_exported,
-                "triples_emitted": report.triples_emitted,
-                "orphan_properties": report.orphan_properties,
-                "orphan_labels": report.orphan_labels,
-                "orphan_relation_types": report.orphan_relation_types,
-                "dangling_edges": report.dangling_edges,
-                "issues": report.issues,
-            })).unwrap_or_default()}
+            {"type": "text", "text": serde_json::to_string(&report).unwrap_or_default()}
         ]
     }))
 }
@@ -298,6 +277,12 @@ pub fn export_data_json_ld(db: &GraphDb, params: Option<Value>) -> Result<Value,
     let doc = sparrowdb_ontology_core::export_data_json_ld(db, &base_iri)
         .map_err(|e| so_error_to_mcp_error(-32603, "Data export failed", &e))?;
 
+    // Re-run for the report; the export itself is read-only, and this gives
+    // callers the same unrepresentable-IRI/orphan/dangling-edge diagnostics
+    // export_data_turtle returns instead of silently omitting them.
+    let (_, report) = sparrowdb_ontology_core::export_data_with_report(db, &base_iri)
+        .map_err(|e| so_error_to_mcp_error(-32603, "Data export failed", &e))?;
+
     let text = serde_json::to_string_pretty(&doc).map_err(|e| {
         mcp_error(
             -32603,
@@ -305,7 +290,12 @@ pub fn export_data_json_ld(db: &GraphDb, params: Option<Value>) -> Result<Value,
             json!({"detail": e.to_string()}),
         )
     })?;
-    Ok(json!({ "content": [{"type": "text", "text": text}] }))
+    Ok(json!({
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "text", "text": serde_json::to_string(&report).unwrap_or_default()}
+        ]
+    }))
 }
 
 pub fn import_data_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, Value> {

--- a/crates/sparrowdb-ontology-mcp/src/tools/data.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/data.rs
@@ -324,11 +324,24 @@ pub fn import_data_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
     let report = sparrowdb_ontology_core::import_data_turtle(db, turtle, strategy)
         .map_err(|e| so_error_to_mcp_error(-32603, "Data import failed", &e))?;
 
+    // A `Result::Ok` here only means the import call didn't hard-fail — the
+    // CLI's `cmd_import_data` treats any skip as a pipeline-gate failure
+    // (`{skipped_total} item(s) were not imported`), and MCP callers need the
+    // same signal. Without `isError`, a strict-mode import where every
+    // subject is an unknown class returns a clean-looking success: the
+    // dispatcher in main.rs only sets `isError` on a hard `Err`, and this
+    // handler always returned `Ok`, so a client that checks `isError` before
+    // parsing content (the documented MCP pattern) would see success on an
+    // import that imported nothing.
+    let skipped_total =
+        report.entities_skipped + report.relationships_skipped + report.blank_nodes_skipped;
+
     Ok(json!({
         "content": [{
             "type": "text",
             "text": serde_json::to_string(&report).unwrap_or_default()
-        }]
+        }],
+        "isError": skipped_total > 0
     }))
 }
 

--- a/crates/sparrowdb-ontology-mcp/src/tools/mod.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/mod.rs
@@ -21,7 +21,11 @@ pub fn handle_tool_call(db: &GraphDb, name: &str, params: Option<Value>) -> Resu
         | "update_entity"
         | "find_entities"
         | "explain_symbol"
-        | "validate" => data::dispatch(db, name, params),
+        | "validate"
+        // Instance-data RDF tools (WS1)
+        | "export_data_turtle"
+        | "export_data_json_ld"
+        | "import_data_turtle" => data::dispatch(db, name, params),
 
         other => Err(mcp_error(
             -32601,

--- a/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
@@ -1455,6 +1455,12 @@ pub fn tool_import_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
         summary.properties_imported,
         summary.skipped_no_domain_properties.len(),
     );
+    if !summary.dropped_property_comments.is_empty() {
+        result_text.push_str(&format!(
+            "\n  Comments not stored (no add_property API): {}",
+            summary.dropped_property_comments.len()
+        ));
+    }
 
     if !summary.warnings.is_empty() {
         result_text.push_str(&format!("\nWarnings ({}):", summary.warnings.len()));

--- a/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
@@ -1447,12 +1447,13 @@ pub fn tool_import_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
         sparrowdb_ontology_core::import_turtle(db, ttl, opts).map_err(|e| so_error_to_mcp(&e))?;
 
     let mut result_text = format!(
-        "Import complete:\n  Classes:    {}\n  Relations:  {}\n  Subclasses: {}\n  Aliases:    {}\n  Properties: {}",
+        "Import complete:\n  Classes:    {}\n  Relations:  {}\n  Subclasses: {}\n  Aliases:    {}\n  Properties: {}\n  Skipped (no domain): {}",
         summary.classes_imported,
         summary.relations_imported,
         summary.subclasses_imported,
         summary.aliases_imported,
         summary.properties_imported,
+        summary.skipped_no_domain_properties.len(),
     );
 
     if !summary.warnings.is_empty() {

--- a/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
@@ -1447,11 +1447,12 @@ pub fn tool_import_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
         sparrowdb_ontology_core::import_turtle(db, ttl, opts).map_err(|e| so_error_to_mcp(&e))?;
 
     let mut result_text = format!(
-        "Import complete:\n  Classes:    {}\n  Relations:  {}\n  Subclasses: {}\n  Aliases:    {}",
+        "Import complete:\n  Classes:    {}\n  Relations:  {}\n  Subclasses: {}\n  Aliases:    {}\n  Properties: {}",
         summary.classes_imported,
         summary.relations_imported,
         summary.subclasses_imported,
         summary.aliases_imported,
+        summary.properties_imported,
     );
 
     if !summary.warnings.is_empty() {

--- a/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
+++ b/crates/sparrowdb-ontology-mcp/src/tools/schema.rs
@@ -975,8 +975,18 @@ pub fn tool_add_property(db: &GraphDb, params: Option<Value>) -> Result<Value, V
         ));
     }
 
-    let prop = add_property(db, owner, name, datatype, required, unique, allowed_values)
-        .map_err(|e| mcp_error(-32602, "add_property failed", so_error_to_mcp(&e)))?;
+    let prop = add_property(
+        db,
+        owner,
+        name,
+        datatype,
+        required,
+        unique,
+        allowed_values,
+        None,
+        None,
+    )
+    .map_err(|e| mcp_error(-32602, "add_property failed", so_error_to_mcp(&e)))?;
 
     Ok(json!({
         "content": [{
@@ -1455,13 +1465,6 @@ pub fn tool_import_turtle(db: &GraphDb, params: Option<Value>) -> Result<Value, 
         summary.properties_imported,
         summary.skipped_no_domain_properties.len(),
     );
-    if !summary.dropped_property_comments.is_empty() {
-        result_text.push_str(&format!(
-            "\n  Comments not stored (no add_property API): {}",
-            summary.dropped_property_comments.len()
-        ));
-    }
-
     if !summary.warnings.is_empty() {
         result_text.push_str(&format!("\nWarnings ({}):", summary.warnings.len()));
         for w in &summary.warnings {

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -313,3 +313,83 @@ Dry-run schema validation without writing.
 ```
 
 Use `validate` in agent planning phases before committing to a write sequence.
+
+---
+
+## Data — RDF (instance data)
+
+These export and import the *entities and relationships*, as opposed to
+`export_json_ld` / `import_turtle` which handle the *schema*. Full detail,
+including the datatype mapping table and IRI minting rules, is in
+[RDF Data Export](rdf-data-export.md).
+
+### `export_data_turtle`
+
+Export every entity and relationship as Turtle.
+
+**Parameters:**
+- `base_iri` (required): namespace entity IRIs are minted under, e.g. `https://example.org/kb`
+
+**Response:** two content blocks — the Turtle document, then a JSON report:
+
+```json
+{
+  "entities_exported": 2,
+  "relationships_exported": 1,
+  "triples_emitted": 6,
+  "orphan_properties": 0,
+  "orphan_labels": [],
+  "orphan_relation_types": [],
+  "dangling_edges": 0,
+  "issues": []
+}
+```
+
+Entities that carry a stored IRI from a previous import keep it; the rest are
+minted as `{base_iri}/{ClassName}/{node_id}`. Export is read-only.
+
+### `export_data_json_ld`
+
+The same graph in JSON-LD 1.1. The `@context` is derived from the ontology:
+relations become `"@type": "@id"` terms, and typed properties carry XSD datatype
+coercions.
+
+**Parameters:**
+- `base_iri` (required)
+
+### `import_data_turtle`
+
+Import instance data through the validated write path. The subject IRI is
+persisted on each entity, so a later export reproduces it rather than minting a
+new one.
+
+**Parameters:**
+- `turtle` (required): the Turtle instance-data text
+- `strategy` (optional, default `strict`): `strict` rejects unknown classes,
+  relations, and properties; `auto_declare` creates them, deriving property
+  types from XSD datatypes and relation domain/range from the observed classes
+
+**Response:**
+```json
+{
+  "entities_imported": 2,
+  "relationships_imported": 1,
+  "entities_skipped": 1,
+  "relationships_skipped": 0,
+  "blank_nodes_skipped": 0,
+  "classes_declared": 0,
+  "relations_declared": 0,
+  "properties_declared": 0,
+  "skips": [
+    {
+      "subject": "https://example.org/kb/Person/2",
+      "reason": "Unknown class <https://example.org/kb/schema/Wizard>. Valid: [\"Concept\", \"Organization\", \"Person\"]. Declare it with define_class, or re-run with ImportStrategy::AutoDeclare."
+    }
+  ],
+  "warnings": []
+}
+```
+
+Nothing is dropped silently — every skipped subject appears in `skips` with its
+IRI and an actionable reason. Blank nodes are counted and skipped (blank-node
+preservation is out of scope).

--- a/docs/rdf-data-export.md
+++ b/docs/rdf-data-export.md
@@ -149,7 +149,7 @@ matching ontology declaration therefore cannot be recovered by name, and cannot
 be exported. Such columns are **counted and reported** as
 `ExportReport::orphan_properties`, with an issue naming the subject and the fix:
 
-```
+```text
 Stored column 'col_1234567890' has no ontology-declared property on class
 'Person'. Property names hash one-way to col_<fnv1a32>, so this value cannot be
 named in RDF. Declare it with add_property(owner='Person', …) and re-export.
@@ -167,7 +167,7 @@ Nothing is ever dropped silently. Every skip is recorded with the offending
 subject IRI and an actionable reason, in the same style as `create_entity`
 errors:
 
-```
+```text
 Unknown property 'favouriteColour' (from <…/schema/favouriteColour>) on class
 'Person'. Valid: ["email", "name"]. Declare it with
 add_property(owner='Person', name='favouriteColour'), or re-run with

--- a/docs/rdf-data-export.md
+++ b/docs/rdf-data-export.md
@@ -213,15 +213,21 @@ the cross-check as skipped rather than passing silently.
 
 ## Engine caveats
 
-Two SparrowDB 0.1.22 behaviours affect this layer:
+As of SparrowDB 0.1.27 (the version this crate pins), the engine refuses to
+create dangling edges rather than leaving them behind:
 
-- `MATCH (n:Label) DELETE n` removes nodes but leaves their edges behind. The
-  resulting dangling edges survive `checkpoint()` and reopen. The exporter
-  **skips** edges whose endpoints no longer exist and counts them in
-  `ExportReport::dangling_edges` — without that guard it would assert facts about
-  deleted entities.
-- `DETACH DELETE` fails outright with
-  `relationship type '__SO_HAS_PROPERTY' not found in catalog`.
+- `MATCH (n:Label) DELETE n` on a node with edges is refused outright
+  (`NodeHasEdges`) instead of silently removing the node and leaving its edges
+  behind.
+- `DETACH DELETE` removes the node and its edges atomically.
+
+Both were bugs on SparrowDB 0.1.22 and earlier — `DELETE` left dangling edges,
+and `DETACH DELETE` failed outright with `relationship type
+'__SO_HAS_PROPERTY' not found in catalog`. Neither is reachable through this
+crate's supported engine version, but the exporter still **skips** edges
+whose endpoints no longer exist and counts them in
+`ExportReport::dangling_edges`, as defense-in-depth for a database written by
+an older engine.
 
 To wipe instance data reliably today, create a fresh database and replay the
 schema rather than deleting in place.

--- a/docs/rdf-data-export.md
+++ b/docs/rdf-data-export.md
@@ -1,0 +1,227 @@
+# Instance-data RDF export and import
+
+`export_json_ld` projects the ontology **schema** (`owl:Class`,
+`owl:ObjectProperty`, …). This document covers the complementary half: exporting
+and importing the **instance data** — the actual entities and relationships.
+
+Together they match the two-file convention Vault-LD uses: `schema.ttl` from the
+schema exporter, `data.ttl` from this one.
+
+| Surface | Export Turtle | Export JSON-LD | Import Turtle |
+|---|---|---|---|
+| Rust | `export_data_turtle(&db, base)` | `export_data_json_ld(&db, base)` | `import_data_turtle(&db, ttl, strategy)` |
+| MCP | `export_data_turtle` | `export_data_json_ld` | `import_data_turtle` |
+| CLI | `export-data --format ttl` | `export-data --format jsonld` | `import-data <file.ttl>` |
+
+`export_data_with_report(&db, base)` returns the Turtle *and* an `ExportReport`
+describing everything that could not be represented. The MCP tool and the CLI
+both surface it.
+
+## Quickstart
+
+```console
+$ sparrow-ontology init --db ./kb
+Initialized: 10 classes, 19 relations, 22 properties
+
+$ sparrow-ontology create-entity Person --db ./kb \
+    --props '{"name":"Ada Lovelace","email":"ada@acme.example"}'
+Created entity: Person  node_id=12884901888
+
+$ sparrow-ontology create-entity Organization --db ./kb --props '{"name":"Acme Corp"}'
+Created entity: Organization  node_id=17179869184
+
+$ sparrow-ontology create-relationship --db ./kb \
+    --from 12884901888 --rel-type WORKS_FOR --to 17179869184
+Created relationship: (12884901888)-[:WORKS_FOR]->(17179869184)
+
+$ sparrow-ontology export-data --db ./kb --format ttl --base https://example.org/kb
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<https://example.org/kb/Organization/17179869184> a <https://example.org/kb/schema/Organization> ;
+	<https://example.org/kb/schema/name> "Acme Corp" .
+<https://example.org/kb/Person/12884901888> a <https://example.org/kb/schema/Person> ;
+	<https://example.org/kb/schema/WORKS_FOR> <https://example.org/kb/Organization/17179869184> ;
+	<https://example.org/kb/schema/email> "ada@acme.example" ;
+	<https://example.org/kb/schema/name> "Ada Lovelace" .
+
+Export complete:
+  Entities:      2
+  Relationships: 1
+  Triples:       6
+```
+
+The graph goes to stdout (or `--out`); the report goes to stderr, so `--out`
+produces a clean RDF file and a stdout pipe stays parseable.
+
+## Datatype mapping
+
+Ontology `PropertyType` → XSD datatype emitted on export:
+
+| `PropertyType` | Emitted datatype | Also accepted on import |
+|---|---|---|
+| `String` | `xsd:string` (plain literal) | anything unrecognised |
+| `Int64` | `xsd:integer` | `int`, `long`, `short`, `byte`, `nonNegativeInteger`, `positiveInteger`, `negativeInteger`, `nonPositiveInteger`, `unsignedLong`, `unsignedInt`, `unsignedShort`, `unsignedByte` |
+| `Float64` | `xsd:double` | `decimal`, `float` |
+| `Bool` | `xsd:boolean` | — |
+| `Date` | `xsd:date` **or** `xsd:dateTime` | both |
+| `Variant` | `xsd:string` | — |
+
+This table is the exact inverse of `xsd_to_type_str` in `turtle_import.rs`. The
+two live in different modules, so they are pinned together by the
+`datatype_mapping_is_a_fixed_point` test, which round-trips every
+`PropertyType` through export → `xsd_to_type_str` → `property_type_from_str` and
+asserts the result is unchanged. Editing one side without the other fails that
+test.
+
+### `xsd:date` vs `xsd:dateTime`
+
+`PropertyType::Date` covers both. Dates are stored as plain strings
+(`PropertyValue` has no `Date` variant — "dates stored as strings in v1"), and
+`xsd_to_type_str` maps both `xsd:date` and `xsd:dateTime` onto `date`.
+
+Emitting a stored `2026-03-01T09:30:00Z` as `^^xsd:date` would be an **ill-typed
+literal** — a malformed lexical form for that datatype. So the exporter picks the
+datatype from the value: a lexical form containing `T` is emitted as
+`xsd:dateTime`, otherwise `xsd:date`. Date round-trips are therefore exact, and
+every emitted literal is well-formed.
+
+### Known lossy edge
+
+`Variant` has no XSD counterpart and is exported as `xsd:string`. Re-importing
+yields `PropertyType::String`, not `Variant`. This is the only type that does not
+survive a round-trip.
+
+## IRI minting and round-trip stability
+
+An entity's subject IRI is, in priority order:
+
+1. the IRI stored on the entity in the reserved `__so_iri` property;
+2. otherwise minted as `{base_iri}/{ClassName}/{node_id}`.
+
+`import_data_turtle` **persists** the subject IRI it read onto each entity it
+creates. That is what makes `export → wipe → import → re-export` reproduce the
+same subject IRIs: minting only ever happens on the first export of a
+never-imported entity.
+
+Without this the round-trip could not be isomorphic — re-import assigns fresh
+node ids, so minted IRIs would change and the second export would describe a
+different graph. This mirrors how `OntologyClass` and `OntologyRelation` already
+carry optional explicit `iri` fields.
+
+**Export is strictly read-only.** It never writes minted IRIs back.
+
+`node_id` is the full label-scoped `NodeId` (`(label_id << 32) | slot`), never
+the bare slot: Organization slot 0 and Person slot 0 are different nodes with ids
+`0` and `4294967296`.
+
+### Class, relation, and property IRIs
+
+| Term | IRI |
+|---|---|
+| Class | its declared `iri`, else `{base}/schema/{ClassName}` |
+| Relation | its declared `iri`, else `{base}/schema/{RELATION_NAME}` |
+| Property | its `source_iri`, else `{base}/schema/{propertyName}` |
+
+The fallback is derived from the **name**, not the `symbol_id`. The schema
+exporter falls back to `so:{symbol_id}`, but `symbol_id` is a fresh UUID on every
+`init`, so a `symbol_id`-derived IRI is not stable across a schema replay and
+would break round-trip isomorphism.
+
+The practical consequence: declare explicit IRIs on your classes and relations
+(`define-class --iri …`, or import a vocabulary with `import_turtle`) and
+`data.ttl` and `schema.ttl` will agree exactly. Without them the two files use
+different IRIs for the same class.
+
+Property predicates are minted from the property name alone, not scoped by
+owning class. This mirrors how RDF vocabularies work — `foaf:name` is one
+predicate regardless of subject class — and it lets import resolve a predicate
+without knowing the subject's class first.
+
+## Only ontology-declared properties are exportable
+
+SparrowDB stores property names as `col_<fnv1a32(name)>` column keys, and **that
+hash is one-way**. To read a property back by name, the exporter builds a reverse
+table: it takes every property the ontology declares, hashes each name, and
+matches the resulting `col_` key.
+
+A property written directly through the low-level `WriteTx` API without a
+matching ontology declaration therefore cannot be recovered by name, and cannot
+be exported. Such columns are **counted and reported** as
+`ExportReport::orphan_properties`, with an issue naming the subject and the fix:
+
+```
+Stored column 'col_1234567890' has no ontology-declared property on class
+'Person'. Property names hash one-way to col_<fnv1a32>, so this value cannot be
+named in RDF. Declare it with add_property(owner='Person', …) and re-export.
+```
+
+## Import strategies
+
+- **`strict`** (default) — reject unknown classes, relations, and properties.
+  The offending subject is skipped and reported; the ontology is not modified.
+- **`auto-declare`** — declare unknown classes, relations, and properties on the
+  fly. Property types are derived from the literal's XSD datatype; relation
+  domain and range from the observed subject and object classes.
+
+Nothing is ever dropped silently. Every skip is recorded with the offending
+subject IRI and an actionable reason, in the same style as `create_entity`
+errors:
+
+```
+Unknown property 'favouriteColour' (from <…/schema/favouriteColour>) on class
+'Person'. Valid: ["email", "name"]. Declare it with
+add_property(owner='Person', name='favouriteColour'), or re-run with
+ImportStrategy::AutoDeclare.
+```
+
+The CLI exits nonzero if anything was skipped, so `import-data` works as a
+pipeline gate.
+
+## Non-goals
+
+Out of scope for this layer, by design:
+
+- **SPARQL query engine** — use Cypher, or export and query elsewhere.
+- **Named graphs** — the export is a single default graph.
+- **Blank-node preservation on import** — blank nodes are counted in
+  `ImportReport::blank_nodes_skipped` and skipped, never silently dropped
+  (Vault-LD §5.6 spirit). The exporter never emits blank nodes, so exported
+  graphs are ground.
+- **Reasoning / inference** — no subclass materialisation, no owl:sameAs
+  resolution. What you wrote is what you get.
+
+Language tags on imported literals are dropped (v1 stores plain strings) and each
+occurrence is recorded in `ImportReport::warnings`.
+
+## Verifying an export
+
+Exported graphs are checked by an independent RDF implementation, not only by the
+oxrdf library that produced them. `tests/tools/verify_rdf.py` is a **test-only**
+script (no runtime dependency) that parses both Turtle exports and the JSON-LD
+through rdflib and asserts pairwise isomorphism:
+
+```console
+$ python3 tests/tools/verify_rdf.py export1.ttl export2.ttl export1.jsonld
+parsed: export1.ttl=42 triples, export2.ttl=42 triples, export1.jsonld=42 triples
+OK: exports are graph-isomorphic (Turtle round-trip and JSON-LD)
+```
+
+The integration test `roundtrip_is_graph_isomorphic` runs it automatically when
+rdflib is importable. Point `SPARROW_RDFLIB_PYTHON` at an interpreter that has
+rdflib to enable it in CI; without it the script exits 77 and the test reports
+the cross-check as skipped rather than passing silently.
+
+## Engine caveats
+
+Two SparrowDB 0.1.22 behaviours affect this layer:
+
+- `MATCH (n:Label) DELETE n` removes nodes but leaves their edges behind. The
+  resulting dangling edges survive `checkpoint()` and reopen. The exporter
+  **skips** edges whose endpoints no longer exist and counts them in
+  `ExportReport::dangling_edges` — without that guard it would assert facts about
+  deleted entities.
+- `DETACH DELETE` fails outright with
+  `relationship type '__SO_HAS_PROPERTY' not found in catalog`.
+
+To wipe instance data reliably today, create a fresh database and replay the
+schema rather than deleting in place.

--- a/tests/integration/test_add_property.rs
+++ b/tests/integration/test_add_property.rs
@@ -18,7 +18,7 @@ fn initialized_db() -> (tempfile::TempDir, GraphDb) {
 fn add_property_to_existing_class() {
     let (_dir, db) = initialized_db();
     // Person already exists in the world model
-    let prop = add_property(&db, "Person", "age", "int64", false, false, None).unwrap();
+    let prop = add_property(&db, "Person", "age", "int64", false, false, None, None, None).unwrap();
     assert_eq!(prop.name, "age");
     assert_eq!(prop.datatype, PropertyType::Int64);
     assert!(!prop.required);
@@ -28,14 +28,14 @@ fn add_property_to_existing_class() {
 #[test]
 fn add_required_property() {
     let (_dir, db) = initialized_db();
-    let prop = add_property(&db, "Task", "deadline", "date", true, false, None).unwrap();
+    let prop = add_property(&db, "Task", "deadline", "date", true, false, None, None, None).unwrap();
     assert!(prop.required);
 }
 
 #[test]
 fn add_property_variant_datatype() {
     let (_dir, db) = initialized_db();
-    let prop = add_property(&db, "Concept", "metadata", "variant", false, false, None).unwrap();
+    let prop = add_property(&db, "Concept", "metadata", "variant", false, false, None, None, None).unwrap();
     assert_eq!(prop.datatype, PropertyType::Variant);
 }
 
@@ -43,7 +43,7 @@ fn add_property_variant_datatype() {
 fn add_property_unknown_class_returns_error() {
     let (_dir, db) = initialized_db();
     let err =
-        add_property(&db, "NonExistentClass", "foo", "string", false, false, None).unwrap_err();
+        add_property(&db, "NonExistentClass", "foo", "string", false, false, None, None, None).unwrap_err();
     assert!(
         matches!(err, SoError::UnknownSymbol { .. }),
         "expected UnknownSymbol, got: {err:?}"
@@ -53,7 +53,7 @@ fn add_property_unknown_class_returns_error() {
 #[test]
 fn add_property_reserved_name_returns_error() {
     let (_dir, db) = initialized_db();
-    let err = add_property(&db, "Person", "__so_secret", "string", false, false, None).unwrap_err();
+    let err = add_property(&db, "Person", "__so_secret", "string", false, false, None, None, None).unwrap_err();
     assert!(
         matches!(err, SoError::ReservedProperty(_)),
         "expected ReservedProperty, got: {err:?}"
@@ -63,8 +63,8 @@ fn add_property_reserved_name_returns_error() {
 #[test]
 fn add_property_duplicate_returns_error() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Person", "nickname", "string", false, false, None).unwrap();
-    let err = add_property(&db, "Person", "nickname", "string", false, false, None).unwrap_err();
+    add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap();
+    let err = add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap_err();
     assert!(
         matches!(err, SoError::DuplicateProperty { .. }),
         "expected DuplicateProperty, got: {err:?}"
@@ -74,7 +74,7 @@ fn add_property_duplicate_returns_error() {
 #[test]
 fn add_property_visible_in_validation_context() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Person", "nickname", "string", false, false, None).unwrap();
+    add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap();
 
     let ctx = ValidationContext::new(&db);
     // Resolve Person's symbol_id first
@@ -94,7 +94,7 @@ fn add_property_visible_in_validation_context() {
 #[test]
 fn add_property_validates_entity_with_new_prop() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Task", "due_date", "date", false, false, None).unwrap();
+    add_property(&db, "Task", "due_date", "date", false, false, None, None, None).unwrap();
 
     let ctx = ValidationContext::new(&db);
     let mut props = HashMap::new();
@@ -124,7 +124,7 @@ fn add_property_via_alias_resolves_owner() {
     .unwrap();
 
     // Add property using the alias "Org" as the owner
-    let prop = add_property(&db, "Org", "industry", "string", false, false, None).unwrap();
+    let prop = add_property(&db, "Org", "industry", "string", false, false, None, None, None).unwrap();
     // Owner resolves to the canonical name
     assert_eq!(prop.owner_name, "Organization");
 }
@@ -133,7 +133,7 @@ fn add_property_via_alias_resolves_owner() {
 fn add_property_unique_stores_flag() {
     let (_dir, db) = initialized_db();
     // Use "badge_id" — not pre-seeded on Person in world model
-    let prop = add_property(&db, "Person", "badge_id", "string", false, true, None).unwrap();
+    let prop = add_property(&db, "Person", "badge_id", "string", false, true, None, None, None).unwrap();
     assert!(prop.unique, "expected unique=true");
 
     // Verify unique flag round-trips through storage
@@ -162,6 +162,8 @@ fn add_property_allowed_values_enforced() {
             "fail".to_string(),
             "skip".to_string(),
         ]),
+        None,
+        None,
     )
     .unwrap();
 
@@ -203,6 +205,8 @@ fn add_property_allowed_values_round_trips() {
         false,
         false,
         Some(allowed.clone()),
+        None,
+        None,
     )
     .unwrap();
     assert_eq!(prop.allowed_values.as_deref(), Some(allowed.as_slice()));

--- a/tests/integration/test_add_property.rs
+++ b/tests/integration/test_add_property.rs
@@ -18,7 +18,10 @@ fn initialized_db() -> (tempfile::TempDir, GraphDb) {
 fn add_property_to_existing_class() {
     let (_dir, db) = initialized_db();
     // Person already exists in the world model
-    let prop = add_property(&db, "Person", "age", "int64", false, false, None, None, None).unwrap();
+    let prop = add_property(
+        &db, "Person", "age", "int64", false, false, None, None, None,
+    )
+    .unwrap();
     assert_eq!(prop.name, "age");
     assert_eq!(prop.datatype, PropertyType::Int64);
     assert!(!prop.required);
@@ -28,22 +31,38 @@ fn add_property_to_existing_class() {
 #[test]
 fn add_required_property() {
     let (_dir, db) = initialized_db();
-    let prop = add_property(&db, "Task", "deadline", "date", true, false, None, None, None).unwrap();
+    let prop = add_property(
+        &db, "Task", "deadline", "date", true, false, None, None, None,
+    )
+    .unwrap();
     assert!(prop.required);
 }
 
 #[test]
 fn add_property_variant_datatype() {
     let (_dir, db) = initialized_db();
-    let prop = add_property(&db, "Concept", "metadata", "variant", false, false, None, None, None).unwrap();
+    let prop = add_property(
+        &db, "Concept", "metadata", "variant", false, false, None, None, None,
+    )
+    .unwrap();
     assert_eq!(prop.datatype, PropertyType::Variant);
 }
 
 #[test]
 fn add_property_unknown_class_returns_error() {
     let (_dir, db) = initialized_db();
-    let err =
-        add_property(&db, "NonExistentClass", "foo", "string", false, false, None, None, None).unwrap_err();
+    let err = add_property(
+        &db,
+        "NonExistentClass",
+        "foo",
+        "string",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .unwrap_err();
     assert!(
         matches!(err, SoError::UnknownSymbol { .. }),
         "expected UnknownSymbol, got: {err:?}"
@@ -53,7 +72,18 @@ fn add_property_unknown_class_returns_error() {
 #[test]
 fn add_property_reserved_name_returns_error() {
     let (_dir, db) = initialized_db();
-    let err = add_property(&db, "Person", "__so_secret", "string", false, false, None, None, None).unwrap_err();
+    let err = add_property(
+        &db,
+        "Person",
+        "__so_secret",
+        "string",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .unwrap_err();
     assert!(
         matches!(err, SoError::ReservedProperty(_)),
         "expected ReservedProperty, got: {err:?}"
@@ -63,8 +93,14 @@ fn add_property_reserved_name_returns_error() {
 #[test]
 fn add_property_duplicate_returns_error() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap();
-    let err = add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap_err();
+    add_property(
+        &db, "Person", "nickname", "string", false, false, None, None, None,
+    )
+    .unwrap();
+    let err = add_property(
+        &db, "Person", "nickname", "string", false, false, None, None, None,
+    )
+    .unwrap_err();
     assert!(
         matches!(err, SoError::DuplicateProperty { .. }),
         "expected DuplicateProperty, got: {err:?}"
@@ -74,7 +110,10 @@ fn add_property_duplicate_returns_error() {
 #[test]
 fn add_property_visible_in_validation_context() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Person", "nickname", "string", false, false, None, None, None).unwrap();
+    add_property(
+        &db, "Person", "nickname", "string", false, false, None, None, None,
+    )
+    .unwrap();
 
     let ctx = ValidationContext::new(&db);
     // Resolve Person's symbol_id first
@@ -94,7 +133,10 @@ fn add_property_visible_in_validation_context() {
 #[test]
 fn add_property_validates_entity_with_new_prop() {
     let (_dir, db) = initialized_db();
-    add_property(&db, "Task", "due_date", "date", false, false, None, None, None).unwrap();
+    add_property(
+        &db, "Task", "due_date", "date", false, false, None, None, None,
+    )
+    .unwrap();
 
     let ctx = ValidationContext::new(&db);
     let mut props = HashMap::new();
@@ -124,7 +166,10 @@ fn add_property_via_alias_resolves_owner() {
     .unwrap();
 
     // Add property using the alias "Org" as the owner
-    let prop = add_property(&db, "Org", "industry", "string", false, false, None, None, None).unwrap();
+    let prop = add_property(
+        &db, "Org", "industry", "string", false, false, None, None, None,
+    )
+    .unwrap();
     // Owner resolves to the canonical name
     assert_eq!(prop.owner_name, "Organization");
 }
@@ -133,7 +178,10 @@ fn add_property_via_alias_resolves_owner() {
 fn add_property_unique_stores_flag() {
     let (_dir, db) = initialized_db();
     // Use "badge_id" — not pre-seeded on Person in world model
-    let prop = add_property(&db, "Person", "badge_id", "string", false, true, None, None, None).unwrap();
+    let prop = add_property(
+        &db, "Person", "badge_id", "string", false, true, None, None, None,
+    )
+    .unwrap();
     assert!(prop.unique, "expected unique=true");
 
     // Verify unique flag round-trips through storage

--- a/tests/integration/test_foaf_import.rs
+++ b/tests/integration/test_foaf_import.rs
@@ -181,6 +181,24 @@ fn foaf_real_happy_path_counts() {
         "expected 2 no-domain warnings (name, homepage), got: {:?}",
         domain_warnings
     );
+    assert_eq!(
+        summary.skipped_no_domain_properties.len(),
+        2,
+        "expected 2 skipped_no_domain_properties, got: {:?}",
+        summary.skipped_no_domain_properties
+    );
+    assert!(
+        summary
+            .skipped_no_domain_properties
+            .contains(&"name".to_string()),
+        "skipped_no_domain_properties must contain 'name'"
+    );
+    assert!(
+        summary
+            .skipped_no_domain_properties
+            .contains(&"homepage".to_string()),
+        "skipped_no_domain_properties must contain 'homepage'"
+    );
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/tests/integration/test_foaf_import.rs
+++ b/tests/integration/test_foaf_import.rs
@@ -148,11 +148,18 @@ fn foaf_real_happy_path_counts() {
         summary.classes_imported
     );
 
-    // 5 object properties + 3 datatype properties = 8 relations
+    // 5 owl:ObjectProperty → 5 relations; 3 owl:DatatypeProperty → add_property
     assert_eq!(
-        summary.relations_imported, 8,
-        "expected 8 relations (knows, member, depiction, account, currentProject, name, mbox, homepage), got {}",
+        summary.relations_imported, 5,
+        "expected 5 relations (knows, member, depiction, account, currentProject), got {}",
         summary.relations_imported
+    );
+
+    // mbox has domain Agent → imported as property; name + homepage have no domain → skipped
+    assert_eq!(
+        summary.properties_imported, 1,
+        "expected 1 data property (mbox on Agent), got {}",
+        summary.properties_imported
     );
 
     // Person→Agent, Organization→Agent, Group→Agent, Image→Document = 4
@@ -162,16 +169,17 @@ fn foaf_real_happy_path_counts() {
         summary.subclasses_imported
     );
 
-    // Filter out the blank-node skip warning if present — no real warnings expected
-    let real_warnings: Vec<_> = summary
+    // name and homepage have no rdfs:domain → 2 warnings; blank-node warning also possible
+    let domain_warnings: Vec<_> = summary
         .warnings
         .iter()
-        .filter(|w| !w.contains("blank-node"))
+        .filter(|w| w.contains("no rdfs:domain"))
         .collect();
-    assert!(
-        real_warnings.is_empty(),
-        "expected no real warnings, got: {:?}",
-        real_warnings
+    assert_eq!(
+        domain_warnings.len(),
+        2,
+        "expected 2 no-domain warnings (name, homepage), got: {:?}",
+        domain_warnings
     );
 }
 
@@ -205,8 +213,8 @@ fn foaf_jsonld_round_trip() {
         );
     }
 
-    // Verify core relations are present
-    for rel_label in &["knows", "member", "name", "mbox", "account"] {
+    // Verify core object-property relations are present (DatatypeProperty → add_property, not @graph)
+    for rel_label in &["knows", "member", "account"] {
         assert!(
             find_node_by_label(graph, rel_label).is_some(),
             "relation '{}' must be present in JSON-LD export",
@@ -281,8 +289,8 @@ fn foaf_idempotent_reimport() {
     let s1 = import_turtle(&db, FOAF_REAL_TTL, ImportOptions::default()).unwrap();
     assert_eq!(s1.classes_imported, 8, "first import: expected 8 classes");
     assert_eq!(
-        s1.relations_imported, 8,
-        "first import: expected 8 relations"
+        s1.relations_imported, 5,
+        "first import: expected 5 object-property relations"
     );
 
     // Second import — must succeed without error
@@ -378,7 +386,7 @@ fn foaf_first_only_strategy() {
 
     // Same counts — strategy only affects multi-domain handling
     assert_eq!(summary.classes_imported, 8);
-    assert_eq!(summary.relations_imported, 8);
+    assert_eq!(summary.relations_imported, 5);
 
     // 'knows' should still have domain/range with FirstOnly
     let doc = export_json_ld(&db).unwrap();

--- a/tests/integration/test_hierarchy.rs
+++ b/tests/integration/test_hierarchy.rs
@@ -137,7 +137,7 @@ fn child_property_overrides_parent_on_validate() {
     seed_test_class(&db, "emp-003", "Employee", "");
     define_subclass(&db, "Employee", "Person").unwrap();
     // Employee also declares `name` explicitly as optional — overrides Person's required `name`.
-    add_property(&db, "Employee", "name", "string", false, false, None).unwrap();
+    add_property(&db, "Employee", "name", "string", false, false, None, None, None).unwrap();
 
     let ctx = ValidationContext::new(&db);
     let empty: HashMap<String, PropertyValue> = HashMap::new();

--- a/tests/integration/test_hierarchy.rs
+++ b/tests/integration/test_hierarchy.rs
@@ -137,7 +137,10 @@ fn child_property_overrides_parent_on_validate() {
     seed_test_class(&db, "emp-003", "Employee", "");
     define_subclass(&db, "Employee", "Person").unwrap();
     // Employee also declares `name` explicitly as optional — overrides Person's required `name`.
-    add_property(&db, "Employee", "name", "string", false, false, None, None, None).unwrap();
+    add_property(
+        &db, "Employee", "name", "string", false, false, None, None, None,
+    )
+    .unwrap();
 
     let ctx = ValidationContext::new(&db);
     let empty: HashMap<String, PropertyValue> = HashMap::new();

--- a/tests/integration/test_jsonld_export.rs
+++ b/tests/integration/test_jsonld_export.rs
@@ -449,7 +449,7 @@ fn class_with_required_property_includes_so_required_properties() {
     let c = OntologyClass::new("Contract", "A legal agreement");
     seed_class(&db, &c);
 
-    add_property(&db, "Contract", "title", "string", true, false, None).unwrap();
+    add_property(&db, "Contract", "title", "string", true, false, None, None, None).unwrap();
 
     let doc = export_json_ld(&db).unwrap();
     let graph = get_graph(&doc);

--- a/tests/integration/test_jsonld_export.rs
+++ b/tests/integration/test_jsonld_export.rs
@@ -449,7 +449,10 @@ fn class_with_required_property_includes_so_required_properties() {
     let c = OntologyClass::new("Contract", "A legal agreement");
     seed_class(&db, &c);
 
-    add_property(&db, "Contract", "title", "string", true, false, None, None, None).unwrap();
+    add_property(
+        &db, "Contract", "title", "string", true, false, None, None, None,
+    )
+    .unwrap();
 
     let doc = export_json_ld(&db).unwrap();
     let graph = get_graph(&doc);

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -1,0 +1,704 @@
+//! WS1 end-to-end tests: instance-data RDF export / import.
+//!
+//! These hit a real `GraphDb` on real disk and include a `checkpoint()` step —
+//! a class of bug in this engine only shows up after a checkpoint, so a test
+//! that never checkpoints does not prove the feature works.
+//!
+//! **Every expected value below is derived by hand from the fixture, with the
+//! derivation written out in a comment.** Nothing here was captured from
+//! program output. Capturing output into assertions is how real bugs get
+//! frozen into a test suite as "expected behaviour".
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use sparrowdb::GraphDb;
+use sparrowdb_common::NodeId;
+use sparrowdb_ontology_core::init::{add_property, init, StarterKind};
+use sparrowdb_ontology_core::rdf_data::{
+    export_data_json_ld, export_data_turtle, export_data_with_report, import_data_turtle,
+    ImportStrategy,
+};
+use sparrowdb_storage::node_store::Value as StoreValue;
+
+const BASE: &str = "https://example.org/kb";
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+//
+// Deliberately MULTI-LABEL and MULTI-RELATION. A single-label fixture cannot
+// reach the bugs this engine produces — node ids are label-scoped
+// (`NodeId = (label_id << 32) | slot`), so Person slot 0 and Organization
+// slot 0 are different nodes with ids 0 and 4294967296. Only a fixture with
+// several labels can catch code that confuses a slot for an identity.
+//
+// Classes used:        Person, Organization, Project        (3  — spec bar: >=3)
+// Entities:            5 + 3 + 3 = 11                       (11 — spec bar: >=10)
+// Relationships:       4 + 4 + 2 = 10                       (10 — spec bar: >=8)
+// Relation types:      WORKS_FOR, KNOWS, OWNS               (3  — spec bar: >=2)
+
+fn sv(s: &str) -> StoreValue {
+    StoreValue::Bytes(s.as_bytes().to_vec())
+}
+
+/// Declare the ontology: the WorldModel starter plus four extra Project
+/// properties chosen to cover every branch of the datatype mapping table
+/// (float64, int64, bool, and a Date holding a dateTime lexical form).
+fn declare_schema(db: &GraphDb) {
+    init(db, Some(StarterKind::WorldModel), false).unwrap();
+    // WorldModel already declares: Person.name/email, Organization.name/description,
+    // Project.name/status/startDate(Date).
+    add_property(
+        db, "Project", "budget", "float64", false, false, None, None, None,
+    )
+    .unwrap();
+    add_property(
+        db,
+        "Project",
+        "headcount",
+        "int64",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    add_property(
+        db, "Project", "active", "bool", false, false, None, None, None,
+    )
+    .unwrap();
+    add_property(
+        db,
+        "Project",
+        "launchedAt",
+        "date",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+}
+
+fn node(db: &GraphDb, label: &str, props: &[(&str, StoreValue)]) -> NodeId {
+    let map: HashMap<String, StoreValue> = props
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect();
+    let mut tx = db.begin_write().unwrap();
+    let nid = tx.merge_node(label, map).unwrap();
+    tx.commit().unwrap();
+    nid
+}
+
+fn edge(db: &GraphDb, src: NodeId, dst: NodeId, rel: &str) {
+    let mut tx = db.begin_write().unwrap();
+    tx.create_edge(src, dst, rel, HashMap::new()).unwrap();
+    tx.commit().unwrap();
+}
+
+/// Seed the fixture described above and checkpoint.
+fn seed(db: &GraphDb) {
+    declare_schema(db);
+
+    // 5 Person
+    let ada = node(
+        db,
+        "Person",
+        &[
+            ("name", sv("Ada Lovelace")),
+            ("email", sv("ada@acme.example")),
+        ],
+    );
+    let bob = node(
+        db,
+        "Person",
+        &[("name", sv("Bob Stone")), ("email", sv("bob@acme.example"))],
+    );
+    let cleo = node(db, "Person", &[("name", sv("Cleo Vance"))]);
+    let dan = node(db, "Person", &[("name", sv("Dan Reyes"))]);
+    let eve = node(db, "Person", &[("name", sv("Eve Nakamura"))]);
+
+    // 3 Organization
+    let acme = node(
+        db,
+        "Organization",
+        &[
+            ("name", sv("Acme Corp")),
+            ("description", sv("A manufacturer")),
+        ],
+    );
+    let borealis = node(db, "Organization", &[("name", sv("Borealis Labs"))]);
+    let cygnus = node(db, "Organization", &[("name", sv("Cygnus Group"))]);
+
+    // 3 Project — Apollo carries one value of every datatype.
+    let apollo = node(
+        db,
+        "Project",
+        &[
+            ("name", sv("Apollo")),
+            ("status", sv("active")),
+            ("startDate", sv("2026-03-01")),
+            ("budget", sv("1250.5")),
+            ("headcount", StoreValue::Int64(7)),
+            ("active", StoreValue::Int64(1)),
+            ("launchedAt", sv("2026-03-01T09:30:00Z")),
+        ],
+    );
+    let beacon = node(
+        db,
+        "Project",
+        &[("name", sv("Beacon")), ("status", sv("planning"))],
+    );
+    // Comet deliberately has no relationships — an entity with no edges must
+    // still export.
+    let _comet = node(db, "Project", &[("name", sv("Comet"))]);
+
+    // 4 WORKS_FOR (Person -> Organization)
+    edge(db, ada, acme, "WORKS_FOR");
+    edge(db, bob, acme, "WORKS_FOR");
+    edge(db, cleo, borealis, "WORKS_FOR");
+    edge(db, dan, cygnus, "WORKS_FOR");
+
+    // 4 KNOWS (Person -> Person)
+    edge(db, ada, bob, "KNOWS");
+    edge(db, bob, cleo, "KNOWS");
+    edge(db, cleo, dan, "KNOWS");
+    edge(db, dan, eve, "KNOWS");
+
+    // 2 OWNS (Person -> Project)
+    edge(db, ada, apollo, "OWNS");
+    edge(db, cleo, beacon, "OWNS");
+
+    // A whole class of bug in this engine only appears after a checkpoint.
+    db.checkpoint().unwrap();
+}
+
+// ── Hand-derived expected totals ──────────────────────────────────────────────
+//
+// rdf:type triples — one per entity:                                       11
+//
+// Data-property triples, counted entity by entity:
+//   Person:  Ada 2 (name,email) + Bob 2 (name,email) + Cleo 1 + Dan 1
+//            + Eve 1                                                      =  7
+//   Organization: Acme 2 (name,description) + Borealis 1 + Cygnus 1       =  4
+//   Project: Apollo 7 (name,status,startDate,budget,headcount,active,
+//                      launchedAt) + Beacon 2 (name,status) + Comet 1     = 10
+//                                                                    subtotal 21
+//
+// Relationship triples:  4 WORKS_FOR + 4 KNOWS + 2 OWNS                   = 10
+//
+// TOTAL                                                       11 + 21 + 10 = 42
+const EXPECTED_ENTITIES: usize = 11;
+const EXPECTED_RELATIONSHIPS: usize = 10;
+const EXPECTED_TRIPLES: usize = 42;
+
+/// Parse Turtle into a set of N-Triples lines.
+///
+/// The exporter emits no blank nodes, so these graphs are *ground*: for ground
+/// graphs, isomorphism coincides with set equality, which is both a stronger
+/// and a far more debuggable assertion. `verify_rdf.py` additionally runs
+/// rdflib's `isomorphic()` over the same files.
+fn parse_to_set(ttl: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for r in oxttl::TurtleParser::new().for_slice(ttl.as_bytes()) {
+        let t = r.expect("exported Turtle must parse cleanly");
+        assert!(
+            !matches!(t.subject, oxrdf::NamedOrBlankNode::BlankNode(_)),
+            "the exporter must not emit blank-node subjects"
+        );
+        assert!(
+            !matches!(t.object, oxrdf::Term::BlankNode(_)),
+            "the exporter must not emit blank-node objects"
+        );
+        out.insert(t.to_string());
+    }
+    out
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Acceptance: exported Turtle parses cleanly, and the graph has exactly the
+/// hand-derived shape.
+#[test]
+fn export_emits_the_hand_derived_graph() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    seed(&db);
+
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+
+    assert_eq!(report.entities_exported, EXPECTED_ENTITIES);
+    assert_eq!(report.relationships_exported, EXPECTED_RELATIONSHIPS);
+    assert_eq!(report.triples_emitted, EXPECTED_TRIPLES);
+    assert_eq!(report.orphan_properties, 0);
+    assert_eq!(report.dangling_edges, 0);
+    assert!(report.orphan_labels.is_empty());
+
+    let triples = parse_to_set(&ttl);
+    assert_eq!(triples.len(), EXPECTED_TRIPLES);
+
+    // Every subject is minted under {base}/{Class}/{node_id}. Node ids are not
+    // asserted: they depend on label-creation order, which is not part of the
+    // contract. The IRI *shape* is.
+    let subjects: HashSet<String> = triples
+        .iter()
+        .map(|t| t.split(' ').next().unwrap().to_string())
+        .collect();
+    assert_eq!(subjects.len(), EXPECTED_ENTITIES);
+    for s in &subjects {
+        assert!(
+            s.starts_with("<https://example.org/kb/Person/")
+                || s.starts_with("<https://example.org/kb/Organization/")
+                || s.starts_with("<https://example.org/kb/Project/"),
+            "unexpected subject IRI shape: {s}"
+        );
+    }
+    // 5 Person + 3 Organization + 3 Project.
+    let count = |p: &str| subjects.iter().filter(|s| s.starts_with(p)).count();
+    assert_eq!(count("<https://example.org/kb/Person/"), 5);
+    assert_eq!(count("<https://example.org/kb/Organization/"), 3);
+    assert_eq!(count("<https://example.org/kb/Project/"), 3);
+}
+
+/// Acceptance: the datatype mapping table, exercised end to end.
+///
+/// Each expected object term is written out from the fixture value and the
+/// mapping table in the `rdf_data` module docs. These are object-side
+/// assertions so they do not depend on node ids.
+#[test]
+fn datatypes_are_emitted_per_the_mapping_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    seed(&db);
+
+    let ttl = export_data_turtle(&db, BASE).unwrap();
+    let triples = parse_to_set(&ttl);
+
+    let has = |pred: &str, obj: &str| {
+        triples
+            .iter()
+            .any(|t| t.contains(&format!("<{BASE}/schema/{pred}> {obj}")))
+    };
+    let xsd = "http://www.w3.org/2001/XMLSchema#";
+
+    // Project.budget is declared float64; Apollo's value is 1250.5.
+    assert!(
+        has("budget", &format!("\"1250.5\"^^<{xsd}double>")),
+        "{ttl}"
+    );
+    // Project.headcount is declared int64; Apollo's value is 7.
+    assert!(has("headcount", &format!("\"7\"^^<{xsd}integer>")), "{ttl}");
+    // Project.active is declared bool; stored as Int64(1) -> "true".
+    assert!(has("active", &format!("\"true\"^^<{xsd}boolean>")), "{ttl}");
+    // Project.startDate is declared Date; "2026-03-01" has no time component.
+    assert!(
+        has("startDate", &format!("\"2026-03-01\"^^<{xsd}date>")),
+        "{ttl}"
+    );
+    // Project.launchedAt is declared Date but holds a dateTime lexical form.
+    // Tagging it ^^xsd:date would be an ill-typed literal, so the exporter
+    // emits ^^xsd:dateTime. See rdf_data::date_datatype_for.
+    assert!(
+        has(
+            "launchedAt",
+            &format!("\"2026-03-01T09:30:00Z\"^^<{xsd}dateTime>")
+        ),
+        "{ttl}"
+    );
+    // Person.name is declared String. RDF 1.1 makes xsd:string implicit, so a
+    // plain literal is what a conforming parser yields.
+    assert!(has("name", "\"Ada Lovelace\""), "{ttl}");
+}
+
+/// **The headline acceptance criterion.**
+///
+/// export -> wipe -> import -> re-export, and the two exports are
+/// graph-isomorphic.
+///
+/// "Wipe" is a fresh database on a fresh directory with the schema re-declared.
+/// It is not an in-place Cypher delete: on SparrowDB 0.1.22
+/// `MATCH (n:Label) DELETE n` removes the nodes but leaves their edges behind
+/// (verified durable across `checkpoint()` and reopen), and `DETACH DELETE`
+/// fails outright with "relationship type '__SO_HAS_PROPERTY' not found in
+/// catalog". Building the round-trip on either would test the engine bug rather
+/// than the exporter. Both are reported upstream; the exporter defends against
+/// the dangling edges they leave (see `dangling_edges_are_skipped_and_reported`).
+#[test]
+fn roundtrip_is_graph_isomorphic() {
+    let dir1 = tempfile::tempdir().unwrap();
+    let db1 = GraphDb::open(dir1.path()).unwrap();
+    seed(&db1);
+
+    let export1 = export_data_turtle(&db1, BASE).unwrap();
+    let jsonld1 = export_data_json_ld(&db1, BASE).unwrap();
+
+    // ── wipe ──────────────────────────────────────────────────────────────────
+    let dir2 = tempfile::tempdir().unwrap();
+    let db2 = GraphDb::open(dir2.path()).unwrap();
+    declare_schema(&db2);
+
+    // Fresh database => fresh symbol_ids for every class and relation. The
+    // exporter derives IRIs from class/relation *names*, never symbol_ids,
+    // precisely so this survives.
+    let report = import_data_turtle(&db2, &export1, ImportStrategy::Strict).unwrap();
+
+    assert_eq!(report.entities_imported, EXPECTED_ENTITIES, "{report:?}");
+    assert_eq!(
+        report.relationships_imported, EXPECTED_RELATIONSHIPS,
+        "{report:?}"
+    );
+    assert_eq!(report.entities_skipped, 0, "{report:?}");
+    assert_eq!(report.relationships_skipped, 0, "{report:?}");
+    assert_eq!(report.blank_nodes_skipped, 0, "{report:?}");
+    // Strict must not have touched the ontology.
+    assert_eq!(report.classes_declared, 0);
+    assert_eq!(report.relations_declared, 0);
+    assert_eq!(report.properties_declared, 0);
+
+    db2.checkpoint().unwrap();
+
+    let export2 = export_data_turtle(&db2, BASE).unwrap();
+
+    // Ground graphs: isomorphism == set equality.
+    let g1 = parse_to_set(&export1);
+    let g2 = parse_to_set(&export2);
+    assert_eq!(g1.len(), EXPECTED_TRIPLES);
+    assert_eq!(
+        g1,
+        g2,
+        "round-trip changed the graph.\nonly in first: {:?}\nonly in second: {:?}",
+        g1.difference(&g2).collect::<Vec<_>>(),
+        g2.difference(&g1).collect::<Vec<_>>()
+    );
+
+    // Subject IRIs must be *identical*, not merely isomorphic: node ids in db2
+    // are freshly assigned, so this only holds because import persisted the
+    // subject IRI onto each entity and export preferred it over minting.
+    let subj = |g: &HashSet<String>| -> HashSet<String> {
+        g.iter()
+            .map(|t| t.split(' ').next().unwrap().to_string())
+            .collect()
+    };
+    assert_eq!(subj(&g1), subj(&g2));
+
+    // Cross-check with an independent RDF implementation when it is available.
+    run_rdflib_check(&export1, &export2, &jsonld1);
+}
+
+/// Acceptance: JSON-LD is the same graph as the Turtle, and validates in a
+/// JSON-LD 1.1 processor.
+#[test]
+fn json_ld_export_is_the_same_graph_as_turtle() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    seed(&db);
+
+    let ttl = export_data_turtle(&db, BASE).unwrap();
+    let jsonld = export_data_json_ld(&db, BASE).unwrap();
+
+    // Structural checks that do not need a JSON-LD processor.
+    let ctx = jsonld["@context"].as_object().expect("@context object");
+    // Relations become terms with "@type": "@id" so their values are IRIs.
+    for rel in ["WORKS_FOR", "KNOWS", "OWNS"] {
+        assert_eq!(ctx[rel]["@type"], "@id", "{rel} should be an @id term");
+        assert_eq!(ctx[rel]["@id"], format!("{BASE}/schema/{rel}"));
+    }
+    // Data properties become terms with an XSD datatype coercion.
+    assert_eq!(
+        ctx["headcount"]["@type"],
+        "http://www.w3.org/2001/XMLSchema#integer"
+    );
+    assert_eq!(
+        ctx["budget"]["@type"],
+        "http://www.w3.org/2001/XMLSchema#double"
+    );
+    // Date terms carry no coercion: the datatype rides on each value, because
+    // a Date property may hold either xsd:date or xsd:dateTime.
+    assert!(ctx["startDate"].get("@type").is_none());
+
+    let graph = jsonld["@graph"].as_array().expect("@graph array");
+    assert_eq!(graph.len(), EXPECTED_ENTITIES);
+
+    // The real check: rdflib parses the JSON-LD and compares it to the Turtle.
+    run_rdflib_check(&ttl, &ttl, &jsonld);
+}
+
+/// Acceptance: the import report surfaces count imported, count skipped, and a
+/// per-skip reason carrying the offending subject IRI.
+#[test]
+fn import_report_surfaces_every_skip_with_its_subject() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    // Four subjects, three of which must be rejected for three distinct reasons.
+    let ttl = format!(
+        r#"
+        <{BASE}/Person/1> a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Valid Person" .
+
+        <{BASE}/Person/2> a <{BASE}/schema/Wizard> ;
+            <{BASE}/schema/name> "Unknown class" .
+
+        <{BASE}/Person/3> a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Bad property" ;
+            <{BASE}/schema/favouriteColour> "teal" .
+
+        <{BASE}/Person/4> <{BASE}/schema/name> "No rdf:type" .
+        "#
+    );
+
+    let report = import_data_turtle(&db, &ttl, ImportStrategy::Strict).unwrap();
+
+    // Only Person/1 is well formed.
+    assert_eq!(report.entities_imported, 1, "{report:?}");
+    assert_eq!(report.entities_skipped, 3, "{report:?}");
+    assert_eq!(report.skips.len(), 3, "{report:?}");
+
+    let reason_for = |iri: &str| -> String {
+        report
+            .skips
+            .iter()
+            .find(|s| s.subject == iri)
+            .unwrap_or_else(|| panic!("no skip recorded for {iri}: {report:?}"))
+            .reason
+            .clone()
+    };
+
+    // Each skip names the offending subject IRI and says what to do about it.
+    let r2 = reason_for(&format!("{BASE}/Person/2"));
+    assert!(r2.contains("Unknown class"), "{r2}");
+    assert!(r2.contains("AutoDeclare"), "{r2}");
+
+    let r3 = reason_for(&format!("{BASE}/Person/3"));
+    assert!(r3.contains("favouriteColour"), "{r3}");
+    assert!(r3.contains("Valid:"), "{r3}");
+
+    let r4 = reason_for(&format!("{BASE}/Person/4"));
+    assert!(r4.contains("rdf:type"), "{r4}");
+}
+
+/// `ImportStrategy::AutoDeclare` declares what `Strict` rejects.
+#[test]
+fn auto_declare_creates_missing_schema() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    init(&db, Some(StarterKind::Blank), false).unwrap();
+
+    // Two classes, one relation, two properties — none of them declared.
+    let ttl = format!(
+        r#"
+        <{BASE}/Wizard/1> a <{BASE}/schema/Wizard> ;
+            <{BASE}/schema/name> "Merlin" ;
+            <{BASE}/schema/level> "42"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+            <{BASE}/schema/MENTORS> <{BASE}/Apprentice/1> .
+
+        <{BASE}/Apprentice/1> a <{BASE}/schema/Apprentice> ;
+            <{BASE}/schema/name> "Nimue" .
+        "#
+    );
+
+    let report = import_data_turtle(&db, &ttl, ImportStrategy::AutoDeclare).unwrap();
+
+    // 2 classes (Wizard, Apprentice); 1 relation (MENTORS); 3 properties
+    // (Wizard.name, Wizard.level, Apprentice.name — name is declared once per
+    // owning class, since properties are class-scoped in this ontology).
+    assert_eq!(report.classes_declared, 2, "{report:?}");
+    assert_eq!(report.relations_declared, 1, "{report:?}");
+    assert_eq!(report.properties_declared, 3, "{report:?}");
+    assert_eq!(report.entities_imported, 2, "{report:?}");
+    assert_eq!(report.relationships_imported, 1, "{report:?}");
+    assert_eq!(report.entities_skipped, 0, "{report:?}");
+
+    db.checkpoint().unwrap();
+
+    // The auto-declared schema must be good enough to export through.
+    let (ttl2, r2) = export_data_with_report(&db, BASE).unwrap();
+    assert_eq!(r2.entities_exported, 2);
+    assert_eq!(r2.relationships_exported, 1);
+    // 2 rdf:type + 3 data properties + 1 relationship = 6 triples.
+    assert_eq!(r2.triples_emitted, 6, "{ttl2}");
+
+    // `level` was auto-declared from ^^xsd:integer, so it must survive as an
+    // integer. Asserted on the *parsed* form, not the Turtle text: Turtle
+    // abbreviates `"42"^^xsd:integer` to a bare `42`, so string-matching the
+    // serialization would test the serializer's shorthand rules, not the
+    // exporter's datatype handling.
+    let triples = parse_to_set(&ttl2);
+    assert!(
+        triples.iter().any(|t| t.contains(&format!(
+            "<{BASE}/schema/level> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer>"
+        ))),
+        "{triples:?}"
+    );
+}
+
+/// A property written without an ontology declaration cannot be named in RDF
+/// (the `col_<fnv1a32>` key is one-way). It must be counted and reported, not
+/// dropped in silence.
+#[test]
+fn orphan_property_is_reported_not_dropped() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    // "name" is declared on Person; "shoeSize" is not. Writing through the
+    // low-level WriteTx API bypasses validation, which is exactly how an
+    // undeclared column comes to exist.
+    node(
+        &db,
+        "Person",
+        &[("name", sv("Ada Lovelace")), ("shoeSize", sv("38"))],
+    );
+    db.checkpoint().unwrap();
+
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+
+    assert_eq!(report.entities_exported, 1);
+    // Exactly one unnameable column.
+    assert_eq!(report.orphan_properties, 1, "{report:?}");
+    // rdf:type + name. shoeSize cannot be emitted.
+    assert_eq!(report.triples_emitted, 2, "{ttl}");
+    assert!(!ttl.contains("shoeSize"));
+
+    let issue = report
+        .issues
+        .iter()
+        .find(|i| i.reason.contains("col_"))
+        .unwrap_or_else(|| panic!("no orphan issue recorded: {report:?}"));
+    assert!(issue.subject.starts_with(&format!("{BASE}/Person/")));
+    assert!(issue.reason.contains("add_property"), "{}", issue.reason);
+}
+
+/// An edge whose endpoint no longer exists must not become a triple.
+///
+/// This is reachable on SparrowDB 0.1.22 because `MATCH (n:Label) DELETE n`
+/// removes nodes without removing their edges. Without the guard, the exporter
+/// would assert facts about deleted entities.
+#[test]
+fn dangling_edges_are_skipped_and_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    let ada = node(&db, "Person", &[("name", sv("Ada Lovelace"))]);
+    let bob = node(&db, "Person", &[("name", sv("Bob Stone"))]);
+    let acme = node(&db, "Organization", &[("name", sv("Acme Corp"))]);
+    edge(&db, ada, bob, "KNOWS");
+    edge(&db, ada, acme, "WORKS_FOR");
+    db.checkpoint().unwrap();
+
+    // Sanity: 3 rdf:type + 3 name + 2 edges = 8 triples before the delete.
+    assert_eq!(
+        export_data_with_report(&db, BASE)
+            .unwrap()
+            .1
+            .triples_emitted,
+        8
+    );
+
+    // Delete both Person nodes. Their KNOWS and WORKS_FOR edges survive.
+    db.execute("MATCH (n:Person) DELETE n").unwrap();
+    db.checkpoint().unwrap();
+
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+
+    // Only Acme remains: 1 rdf:type + 1 name = 2 triples.
+    assert_eq!(report.entities_exported, 1, "{ttl}");
+    assert_eq!(report.triples_emitted, 2, "{ttl}");
+    // KNOWS (Ada->Bob) and WORKS_FOR (Ada->Acme) both lost their source.
+    assert_eq!(report.dangling_edges, 2, "{report:?}");
+    assert_eq!(report.relationships_exported, 0);
+    assert!(!ttl.contains("KNOWS"));
+    assert!(!ttl.contains("WORKS_FOR"));
+}
+
+/// Acceptance: `export_json_ld` (schema) behaviour is unchanged.
+///
+/// WS1 is additive. The schema exporter must still key its `@id` off
+/// `so:{symbol_id}` and emit owl:Class / owl:ObjectProperty exactly as before.
+#[test]
+fn schema_export_json_ld_is_unchanged() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    seed(&db);
+
+    let doc = sparrowdb_ontology_core::export_json_ld(&db).unwrap();
+    let ctx = &doc["@context"];
+    assert_eq!(ctx["owl"], "http://www.w3.org/2002/07/owl#");
+    assert_eq!(ctx["so"], "http://sparrowontology.io/schema#");
+
+    let graph = doc["@graph"].as_array().unwrap();
+    // WorldModel declares 10 classes and 19 relations.
+    let classes = graph.iter().filter(|n| n["@type"] == "owl:Class").count();
+    let rels = graph
+        .iter()
+        .filter(|n| n["@type"] == "owl:ObjectProperty")
+        .count();
+    assert_eq!(classes, 10);
+    assert_eq!(rels, 19);
+
+    // Unchanged fallback: no explicit IRI => "so:" + symbol_id.
+    let person = graph
+        .iter()
+        .find(|n| n["rdfs:label"] == "Person")
+        .expect("Person class");
+    assert!(
+        person["@id"].as_str().unwrap().starts_with("so:"),
+        "{person}"
+    );
+}
+
+// ── rdflib cross-check ────────────────────────────────────────────────────────
+
+/// Shell out to `tests/tools/verify_rdf.py` for an independent isomorphism
+/// check using rdflib.
+///
+/// The native oxrdf assertions above always run and are the hard gate. This
+/// adds a *second, independent* implementation's opinion, which is what the
+/// spec asks for. If rdflib is not installed the script exits 77 and this is
+/// reported as skipped — never silently treated as a pass.
+fn run_rdflib_check(ttl1: &str, ttl2: &str, jsonld: &serde_json::Value) {
+    let dir = tempfile::tempdir().unwrap();
+    let p1 = dir.path().join("export1.ttl");
+    let p2 = dir.path().join("export2.ttl");
+    let pj = dir.path().join("export1.jsonld");
+    std::fs::write(&p1, ttl1).unwrap();
+    std::fs::write(&p2, ttl2).unwrap();
+    std::fs::write(&pj, serde_json::to_string_pretty(jsonld).unwrap()).unwrap();
+
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/tools/verify_rdf.py")
+        .canonicalize()
+        .expect("verify_rdf.py must exist");
+
+    // SPARROW_RDFLIB_PYTHON lets CI point at an interpreter that has rdflib.
+    let python = std::env::var("SPARROW_RDFLIB_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    let out = match std::process::Command::new(&python)
+        .arg(&script)
+        .arg(&p1)
+        .arg(&p2)
+        .arg(&pj)
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("rdflib cross-check SKIPPED: cannot run {python}: {e}");
+            return;
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    match out.status.code() {
+        Some(0) => eprintln!("rdflib cross-check PASSED: {}", stdout.trim()),
+        // 77 is the script's "rdflib not installed" signal.
+        Some(77) => eprintln!(
+            "rdflib cross-check SKIPPED: rdflib not installed. \
+             Set SPARROW_RDFLIB_PYTHON to an interpreter that has it."
+        ),
+        _ => panic!("rdflib cross-check FAILED:\n{stdout}\n{stderr}"),
+    }
+}

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -98,6 +98,28 @@ fn edge(db: &GraphDb, src: NodeId, dst: NodeId, rel: &str) {
     tx.commit().unwrap();
 }
 
+/// Declare a class with no `iri` set, bypassing `define_class`'s validation
+/// (which only rejects the `__SO_`-reserved prefix, not arbitrary characters)
+/// so the default-minted class IRI (`{base}/schema/{name}`) is exercised with
+/// a name that cannot form a valid IRI segment.
+fn define_class_raw(db: &GraphDb, name: &str) {
+    let props: HashMap<String, StoreValue> = [
+        ("symbol_id".to_string(), sv(&format!("test-symbol-{name}"))),
+        ("name".to_string(), sv(name)),
+        ("description".to_string(), sv("")),
+        ("status".to_string(), sv("active")),
+        ("iri".to_string(), sv("")),
+        ("created_at".to_string(), StoreValue::Int64(0)),
+        ("updated_at".to_string(), StoreValue::Int64(0)),
+    ]
+    .into_iter()
+    .collect();
+    let mut tx = db.begin_write().unwrap();
+    tx.merge_node(sparrowdb_ontology_core::namespace::CLASS_LABEL, props)
+        .unwrap();
+    tx.commit().unwrap();
+}
+
 /// Seed the fixture described above and checkpoint.
 fn seed(db: &GraphDb) {
     declare_schema(db);
@@ -613,6 +635,92 @@ fn dangling_edges_are_skipped_and_reported() {
     assert_eq!(report.relationships_exported, 0);
     assert!(!ttl.contains("KNOWS"));
     assert!(!ttl.contains("WORKS_FOR"));
+}
+
+/// A node whose subject IRI cannot be parsed (here: a stored `__so_iri` with
+/// an embedded space, which `NamedNode::new` rejects) must be skipped and
+/// reported, not abort the entire export — the same contract the module
+/// already honours for orphan labels/properties and dangling edges.
+#[test]
+fn unrepresentable_subject_iri_is_skipped_not_fatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    let bad = node(
+        &db,
+        "Person",
+        &[
+            ("name", sv("Bad Iri")),
+            ("__so_iri", sv("not a valid iri with spaces")),
+        ],
+    );
+    let good = node(&db, "Person", &[("name", sv("Good Node"))]);
+    edge(&db, bad, good, "KNOWS");
+    db.checkpoint().unwrap();
+
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+
+    // Only the good node exports: 1 rdf:type + 1 name = 2 triples.
+    assert_eq!(report.entities_exported, 1, "{ttl}");
+    assert_eq!(report.triples_emitted, 2, "{ttl}");
+    assert_eq!(report.unrepresentable_iris, 1, "{report:?}");
+    assert!(
+        report
+            .issues
+            .iter()
+            .any(|i| i.reason.contains("could not be represented in RDF")),
+        "{report:?}"
+    );
+    // The KNOWS edge lost its source (the bad node was never inserted into
+    // subject_by_id), so it's reported as dangling rather than half-exported.
+    assert_eq!(report.dangling_edges, 1, "{report:?}");
+    assert!(!ttl.contains("KNOWS"));
+    assert!(!ttl.contains("Bad Iri"));
+    assert!(ttl.contains("Good Node"), "{ttl}");
+}
+
+/// A class whose IRI (default-minted from its name) cannot be parsed — e.g. a
+/// class name containing a space, which is not rejected by `define_class`
+/// today — must skip that class's nodes and report it, not abort the whole
+/// export. This is the same failure mode `unrepresentable_subject_iri_is_skipped_not_fatal`
+/// covers, but at the class/label granularity instead of the per-node one.
+#[test]
+fn unrepresentable_class_iri_is_skipped_not_fatal() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    define_class_raw(&db, "Online Account");
+    add_property(
+        &db,
+        "Online Account",
+        "handle",
+        "string",
+        false,
+        false,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    node(&db, "Online Account", &[("handle", sv("@example"))]);
+    let person = node(&db, "Person", &[("name", sv("Ada Lovelace"))]);
+    db.checkpoint().unwrap();
+
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+
+    // Only Person exports: 1 rdf:type + 1 name = 2 triples.
+    assert_eq!(report.entities_exported, 1, "{ttl}");
+    assert_eq!(report.triples_emitted, 2, "{ttl}");
+    assert_eq!(report.unrepresentable_iris, 1, "{report:?}");
+    assert!(
+        report.issues.iter().any(|i| i.subject == "Online Account"
+            && i.reason.contains("could not be represented in RDF")),
+        "{report:?}"
+    );
+    assert!(!ttl.contains("@example"));
+    let _ = person;
 }
 
 /// Acceptance: `export_json_ld` (schema) behaviour is unchanged.

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -594,13 +594,63 @@ fn orphan_property_is_reported_not_dropped() {
     assert!(issue.reason.contains("add_property"), "{}", issue.reason);
 }
 
-/// An edge whose endpoint no longer exists must not become a triple.
+/// `dangling_edges` in [`ExportReport`] guards against a node being removed
+/// while its edges survive it — which would otherwise let the exporter
+/// assert facts about a deleted entity. On SparrowDB through 0.1.25,
+/// `MATCH (n:Label) DELETE n` reached exactly that state: a packed `NodeId`
+/// was passed where the edge-detection lookup expected a slot, so the lookup
+/// silently found nothing and the delete proceeded, leaving `KNOWS`/`WORKS_FOR`
+/// edges pointing at a node that no longer existed.
 ///
-/// This is reachable on SparrowDB 0.1.22 because `MATCH (n:Label) DELETE n`
-/// removes nodes without removing their edges. Without the guard, the exporter
-/// would assert facts about deleted entities.
+/// SparrowDB 0.1.27 (`#436`, upstream PR #512) fixed the lookup itself: plain
+/// `DELETE` on a node with edges is now refused outright with
+/// `NodeHasEdges` — not a value change, a bug fix to a check that was always
+/// meant to fire — and `DETACH DELETE` removes the node and its edges
+/// atomically. Traced through SparrowDB's WAL replay
+/// (`sparrowdb-storage/src/wal/replay.rs`): mutations only replay for
+/// transactions with a matching `Begin`+`Commit` pair, so a transaction that
+/// fails the edge check (and therefore never reaches `Commit`) cannot leave a
+/// partial trace, and a successful `DETACH DELETE`'s node- and edge-removal
+/// mutations share one `txn_id` and replay together or not at all. So as of
+/// 0.1.27 this scenario is not constructible through the public API by any
+/// path — DELETE, DETACH DELETE, or crash/WAL-replay recovery.
+///
+/// The exporter's `dangling_edges` guard is kept regardless: it is cheap,
+/// and it still protects a database created under a pre-0.1.27 SparrowDB
+/// (whose on-disk state could already contain the inconsistency this test
+/// used to construct) or any future storage-layer regression. This test now
+/// asserts the *current* contract instead — DELETE is refused, DETACH DELETE
+/// is clean — rather than a bug that no longer exists.
 #[test]
-fn dangling_edges_are_skipped_and_reported() {
+fn delete_on_edge_bearing_node_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    let ada = node(&db, "Person", &[("name", sv("Ada Lovelace"))]);
+    let bob = node(&db, "Person", &[("name", sv("Bob Stone"))]);
+    edge(&db, ada, bob, "KNOWS");
+    db.checkpoint().unwrap();
+
+    let err = db.execute("MATCH (n:Person {name: 'Ada Lovelace'}) DELETE n");
+    assert!(
+        err.is_err(),
+        "DELETE on a node with edges must be refused, not silently leave them dangling"
+    );
+
+    // The refusal must be all-or-nothing: both nodes and the edge survive.
+    let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
+    assert_eq!(report.entities_exported, 2, "{ttl}");
+    assert_eq!(report.relationships_exported, 1, "{ttl}");
+    assert_eq!(report.dangling_edges, 0, "{report:?}");
+    assert!(ttl.contains("KNOWS"), "{ttl}");
+}
+
+/// `DETACH DELETE` removes a node and its edges atomically — the export
+/// reflects a fully consistent graph afterward, with no orphaned/dangling
+/// triples for the removed relationships.
+#[test]
+fn detach_delete_leaves_a_consistent_export() {
     let dir = tempfile::tempdir().unwrap();
     let db = GraphDb::open(dir.path()).unwrap();
     declare_schema(&db);
@@ -621,20 +671,22 @@ fn dangling_edges_are_skipped_and_reported() {
         8
     );
 
-    // Delete both Person nodes. Their KNOWS and WORKS_FOR edges survive.
-    db.execute("MATCH (n:Person) DELETE n").unwrap();
+    db.execute("MATCH (n:Person {name: 'Ada Lovelace'}) DETACH DELETE n")
+        .unwrap();
     db.checkpoint().unwrap();
 
     let (ttl, report) = export_data_with_report(&db, BASE).unwrap();
 
-    // Only Acme remains: 1 rdf:type + 1 name = 2 triples.
-    assert_eq!(report.entities_exported, 1, "{ttl}");
-    assert_eq!(report.triples_emitted, 2, "{ttl}");
-    // KNOWS (Ada->Bob) and WORKS_FOR (Ada->Acme) both lost their source.
-    assert_eq!(report.dangling_edges, 2, "{report:?}");
+    // Bob and Acme remain: 2 rdf:type + 2 name = 4 triples. No dangling edges
+    // — DETACH DELETE took KNOWS and WORKS_FOR with it.
+    assert_eq!(report.entities_exported, 2, "{ttl}");
+    assert_eq!(report.triples_emitted, 4, "{ttl}");
+    assert_eq!(report.dangling_edges, 0, "{report:?}");
     assert_eq!(report.relationships_exported, 0);
     assert!(!ttl.contains("KNOWS"));
     assert!(!ttl.contains("WORKS_FOR"));
+    assert!(ttl.contains("Bob Stone"), "{ttl}");
+    assert!(ttl.contains("Acme Corp"), "{ttl}");
 }
 
 /// A node whose subject IRI cannot be parsed (here: a stored `__so_iri` with

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -634,8 +634,8 @@ fn delete_on_edge_bearing_node_is_refused() {
 
     let err = db.execute("MATCH (n:Person {name: 'Ada Lovelace'}) DELETE n");
     assert!(
-        err.is_err(),
-        "DELETE on a node with edges must be refused, not silently leave them dangling"
+        matches!(err, Err(sparrowdb::Error::NodeHasEdges { .. })),
+        "expected NodeHasEdges, got: {err:?}"
     );
 
     // The refusal must be all-or-nothing: both nodes and the edge survive.

--- a/tests/integration/test_schema_snapshot.rs
+++ b/tests/integration/test_schema_snapshot.rs
@@ -158,9 +158,11 @@ fn snapshot_roundtrip_property_with_unique_and_allowed_values() {
             "medium".to_string(),
             "high".to_string(),
         ]),
+        None,
+        None,
     )
     .unwrap();
-    add_property(&db_a, "Person", "badge_id", "string", false, true, None).unwrap();
+    add_property(&db_a, "Person", "badge_id", "string", false, true, None, None, None).unwrap();
 
     let snap = export_schema(&db_a).unwrap();
     drop(db_a);

--- a/tests/integration/test_schema_snapshot.rs
+++ b/tests/integration/test_schema_snapshot.rs
@@ -162,7 +162,10 @@ fn snapshot_roundtrip_property_with_unique_and_allowed_values() {
         None,
     )
     .unwrap();
-    add_property(&db_a, "Person", "badge_id", "string", false, true, None, None, None).unwrap();
+    add_property(
+        &db_a, "Person", "badge_id", "string", false, true, None, None, None,
+    )
+    .unwrap();
 
     let snap = export_schema(&db_a).unwrap();
     drop(db_a);

--- a/tests/integration/test_schemaorg_import.rs
+++ b/tests/integration/test_schemaorg_import.rs
@@ -10,7 +10,7 @@
 
 use sparrowdb::GraphDb;
 use sparrowdb_ontology_core::{
-    export_json_ld, init,
+    export_json_ld, export_schema, init,
     turtle_import::{import_turtle, DomainRangeStrategy, ImportOptions},
     StarterKind,
 };
@@ -128,10 +128,17 @@ fn schemaorg_subset_import_counts() {
         "expected 4 classes (Thing, Person, Organization, LocalBusiness), got {}",
         summary.classes_imported
     );
+    // 3 owl:ObjectProperty → relations; 2 owl:DatatypeProperty → add_property
     assert_eq!(
-        summary.relations_imported, 5,
-        "expected 5 relations (name, worksFor, email, member, parentOrganization), got {}",
+        summary.relations_imported, 3,
+        "expected 3 relations (worksFor, member, parentOrganization), got {}",
         summary.relations_imported
+    );
+    // name → Thing (1); email → Person + Organization (2) = 3 properties
+    assert_eq!(
+        summary.properties_imported, 3,
+        "expected 3 data properties (name/Thing, email/Person, email/Organization), got {}",
+        summary.properties_imported
     );
     assert_eq!(
         summary.subclasses_imported, 3,
@@ -209,14 +216,14 @@ fn single_domain_includes_resolved() {
     };
     import_turtle(&db, SCHEMAORG_SUBSET_TTL, opts).unwrap();
 
-    let doc = export_json_ld(&db).unwrap();
-    let graph = get_graph(&doc);
-
-    // schema:name has single domainIncludes (Thing) → domain should be set
-    let name_node = find_node_by_label(graph, "name").expect("'name' relation not found");
+    // schema:name is owl:DatatypeProperty with single domainIncludes (Thing)
+    // → imported as add_property on Thing, not as a relation in @graph
+    let snap = export_schema(&db).unwrap();
     assert!(
-        name_node.get("rdfs:domain").is_some(),
-        "rdfs:domain must be present for 'name' (single domainIncludes → Thing)"
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Thing" && p.name == "name"),
+        "'name' property must be on Thing class (owl:DatatypeProperty → add_property)"
     );
 }
 
@@ -233,14 +240,20 @@ fn multi_domain_includes_drops_domain_unconstrained() {
     };
     import_turtle(&db, SCHEMAORG_SUBSET_TTL, opts).unwrap();
 
-    let doc = export_json_ld(&db).unwrap();
-    let graph = get_graph(&doc);
-
-    // schema:email has 2 domainIncludes (Person, Organization) → domain absent
-    let email_node = find_node_by_label(graph, "email").expect("'email' relation not found");
+    // schema:email is owl:DatatypeProperty with 2 domainIncludes (Person, Organization)
+    // → imported as add_property on both classes (not a relation)
+    let snap = export_schema(&db).unwrap();
     assert!(
-        email_node.get("rdfs:domain").is_none(),
-        "rdfs:domain must be absent for 'email' (multiple domainIncludes with Unconstrained)"
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Person" && p.name == "email"),
+        "'email' property must be on Person class"
+    );
+    assert!(
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Organization" && p.name == "email"),
+        "'email' property must be on Organization class"
     );
 }
 
@@ -346,14 +359,20 @@ fn first_only_strategy_keeps_domain() {
     };
     import_turtle(&db, SCHEMAORG_SUBSET_TTL, opts).unwrap();
 
-    let doc = export_json_ld(&db).unwrap();
-    let graph = get_graph(&doc);
-
-    // With FirstOnly, email (multi domainIncludes) should still have a domain
-    let email_node = find_node_by_label(graph, "email").expect("'email' relation not found");
+    // owl:DatatypeProperty → add_property regardless of strategy
+    // email with 2 domainIncludes → property on both Person and Organization
+    let snap = export_schema(&db).unwrap();
     assert!(
-        email_node.get("rdfs:domain").is_some(),
-        "rdfs:domain must be present for 'email' with FirstOnly strategy"
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Person" && p.name == "email"),
+        "'email' must be on Person even with FirstOnly strategy"
+    );
+    assert!(
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Organization" && p.name == "email"),
+        "'email' must be on Organization even with FirstOnly strategy"
     );
 }
 
@@ -373,10 +392,8 @@ fn round_trip_no_data_loss() {
     let doc = export_json_ld(&db).unwrap();
     let graph = get_graph(&doc);
 
-    // Count classes (type = owl:Class or rdfs:Class) and relations
+    // Verify classes survive round-trip
     let class_labels = ["Thing", "Person", "Organization", "LocalBusiness"];
-    let relation_labels = ["name", "worksFor", "email", "member", "parentOrganization"];
-
     for label in &class_labels {
         assert!(
             find_node_by_label(graph, label).is_some(),
@@ -384,12 +401,29 @@ fn round_trip_no_data_loss() {
         );
     }
 
+    // owl:ObjectProperty relations survive in @graph
+    let relation_labels = ["worksFor", "member", "parentOrganization"];
     for label in &relation_labels {
         assert!(
             find_node_by_label(graph, label).is_some(),
             "relation '{label}' missing from JSON-LD round-trip"
         );
     }
+
+    // owl:DatatypeProperty values survive as class properties (not in @graph)
+    let snap = export_schema(&db).unwrap();
+    assert!(
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Thing" && p.name == "name"),
+        "'name' property on Thing missing from round-trip"
+    );
+    assert!(
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Person" && p.name == "email"),
+        "'email' property on Person missing from round-trip"
+    );
 
     // Verify descriptions survived
     let thing = find_node_by_label(graph, "Thing").expect("Thing not found");

--- a/tests/integration/test_turtle_import.rs
+++ b/tests/integration/test_turtle_import.rs
@@ -646,4 +646,122 @@ ex:orphan a owl:DatatypeProperty ;
         "warning must mention missing domain, got: {}",
         summary.warnings[0]
     );
+    assert_eq!(
+        summary.skipped_no_domain_properties.len(),
+        1,
+        "expected 1 skipped_no_domain_properties entry"
+    );
+    assert!(
+        summary
+            .skipped_no_domain_properties
+            .contains(&"orphan".to_string()),
+        "skipped_no_domain_properties must contain 'orphan'"
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Test 16 — DatatypeProperty type conflict on re-import emits warning (issue #38)
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn datatype_property_type_conflict_warns_on_reimport() {
+    let (_dir, db) = blank_db();
+
+    // First import: age is xsd:integer → int64
+    let ttl_v1 = r#"
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <https://example.org/> .
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" .
+
+ex:age a owl:DatatypeProperty ;
+    rdfs:label "age" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:integer .
+"#;
+
+    let s1 = import_turtle(&db, ttl_v1, ImportOptions::default()).unwrap();
+    assert_eq!(
+        s1.properties_imported, 1,
+        "first import: expected 1 property"
+    );
+    assert!(
+        s1.warnings.is_empty(),
+        "first import must have no warnings, got: {:?}",
+        s1.warnings
+    );
+
+    // Second import: age is xsd:string → string (type change!)
+    let ttl_v2 = r#"
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <https://example.org/> .
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" .
+
+ex:age a owl:DatatypeProperty ;
+    rdfs:label "age" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:string .
+"#;
+
+    let s2 = import_turtle(&db, ttl_v2, ImportOptions::default()).unwrap();
+
+    // The property already exists so properties_imported stays 0 for the second pass
+    assert_eq!(
+        s2.properties_imported, 0,
+        "second import: duplicate property must not increment properties_imported"
+    );
+
+    // A type-conflict warning must be emitted
+    assert!(
+        !s2.warnings.is_empty(),
+        "second import: expected a type-conflict warning, got none"
+    );
+    assert!(
+        s2.warnings.iter().any(|w| w.contains("type conflict")),
+        "warning must contain 'type conflict', got: {:?}",
+        s2.warnings
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Test 17 — DatatypeProperty same-type re-import: no type conflict warning
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn datatype_property_same_type_reimport_no_warning() {
+    let (_dir, db) = blank_db();
+
+    // Import once
+    let s1 = import_turtle(&db, DATATYPE_TTL, ImportOptions::default()).unwrap();
+    assert_eq!(
+        s1.properties_imported, 5,
+        "first import: expected 5 properties"
+    );
+    assert!(
+        s1.warnings.is_empty(),
+        "first import must have no warnings, got: {:?}",
+        s1.warnings
+    );
+
+    // Re-import the identical Turtle — no type conflict, no warnings
+    let s2 = import_turtle(&db, DATATYPE_TTL, ImportOptions::default()).unwrap();
+
+    let type_conflict_warnings: Vec<&String> = s2
+        .warnings
+        .iter()
+        .filter(|w| w.contains("type conflict"))
+        .collect();
+
+    assert!(
+        type_conflict_warnings.is_empty(),
+        "same-type re-import must not emit type conflict warnings, got: {:?}",
+        type_conflict_warnings
+    );
 }

--- a/tests/integration/test_turtle_import.rs
+++ b/tests/integration/test_turtle_import.rs
@@ -510,6 +510,7 @@ ex:Person a owl:Class ;
 
 ex:age a owl:DatatypeProperty ;
     rdfs:label "age" ;
+    rdfs:comment "Age in years." ;
     rdfs:domain ex:Person ;
     rdfs:range xsd:integer .
 
@@ -570,6 +571,22 @@ fn datatype_properties_imported_as_add_property() {
     assert!(names.contains(&"score"), "missing 'score'");
     assert!(names.contains(&"active"), "missing 'active'");
     assert!(names.contains(&"joinedAt"), "missing 'joinedAt'");
+
+    // Verify the new metadata fields are persisted through the import → export round-trip.
+    let age_prop = person_props
+        .iter()
+        .find(|p| p.name == "age")
+        .expect("'age' property must exist");
+    assert_eq!(
+        age_prop.description.as_deref(),
+        Some("Age in years."),
+        "rdfs:comment must be stored as description"
+    );
+    assert_eq!(
+        age_prop.source_iri.as_deref(),
+        Some("https://example.org/age"),
+        "source IRI must be stored from owl:DatatypeProperty IRI"
+    );
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/tests/integration/test_turtle_import.rs
+++ b/tests/integration/test_turtle_import.rs
@@ -7,10 +7,12 @@
 
 use sparrowdb::GraphDb;
 use sparrowdb_ontology_core::{
-    export_json_ld, init,
+    export_json_ld, export_schema, init,
     turtle_import::{import_turtle, DomainRangeStrategy, ImportOptions},
-    StarterKind,
+    PropertyType, StarterKind,
 };
+
+// Covers also: owl:DatatypeProperty → add_property (issue #35)
 
 // ── DB helpers ─────────────────────────────────────────────────────────────────
 
@@ -146,20 +148,28 @@ schema:name a owl:DatatypeProperty ;
     };
     let summary = import_turtle(&db, ttl, opts).unwrap();
 
+    // owl:DatatypeProperty maps to add_property, not a relation.
+    // With two domain classes, the property is added to each.
     assert_eq!(
-        summary.relations_imported, 1,
-        "expected 1 relation (name), got {}",
-        summary.relations_imported
+        summary.relations_imported, 0,
+        "owl:DatatypeProperty must not create relations"
+    );
+    assert_eq!(
+        summary.properties_imported, 2,
+        "expected 1 property per domain class (Person + Organization), got {}",
+        summary.properties_imported
     );
 
-    // With Unconstrained strategy and 2 domains, no rdfs:domain edge is created.
-    let doc = export_json_ld(&db).unwrap();
-    let graph = get_graph(&doc);
-    let rel_node = find_node_by_label(graph, "name").expect("'name' relation not found in @graph");
-
+    let snap = export_schema(&db).unwrap();
+    let has_name = |owner: &str| {
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == owner && p.name == "name")
+    };
+    assert!(has_name("Person"), "'name' property missing on Person");
     assert!(
-        rel_node.get("rdfs:domain").is_none(),
-        "rdfs:domain must be absent when multiple domainIncludes values exist with Unconstrained strategy"
+        has_name("Organization"),
+        "'name' property missing on Organization"
     );
 }
 
@@ -188,17 +198,24 @@ schema:email a owl:DatatypeProperty ;
         base_iri: None,
         domain_range_strategy: DomainRangeStrategy::Unconstrained,
     };
-    import_turtle(&db, ttl, opts).unwrap();
+    let summary = import_turtle(&db, ttl, opts).unwrap();
 
-    let doc = export_json_ld(&db).unwrap();
-    let graph = get_graph(&doc);
-    let rel_node =
-        find_node_by_label(graph, "email").expect("'email' relation not found in @graph");
+    // owl:DatatypeProperty → add_property on the domain class, not a relation.
+    assert_eq!(
+        summary.relations_imported, 0,
+        "owl:DatatypeProperty must not create relations"
+    );
+    assert_eq!(
+        summary.properties_imported, 1,
+        "expected 1 data property imported"
+    );
 
-    // Single domainIncludes with Unconstrained → domain is set
+    let snap = export_schema(&db).unwrap();
     assert!(
-        rel_node.get("rdfs:domain").is_some(),
-        "rdfs:domain must be present when exactly one domainIncludes value exists"
+        snap.properties
+            .iter()
+            .any(|p| p.owner_name == "Person" && p.name == "email"),
+        "'email' property must be added to Person class"
     );
 }
 
@@ -475,5 +492,158 @@ fn empty_turtle_returns_empty_summary() {
     assert!(
         summary.warnings.is_empty(),
         "empty input: warnings must be empty"
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Test 13 — owl:DatatypeProperty → add_property (issue #35)
+// ══════════════════════════════════════════════════════════════════════════════
+
+const DATATYPE_TTL: &str = r#"
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <https://example.org/> .
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" .
+
+ex:age a owl:DatatypeProperty ;
+    rdfs:label "age" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:integer .
+
+ex:name a owl:DatatypeProperty ;
+    rdfs:label "name" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:string .
+
+ex:score a owl:DatatypeProperty ;
+    rdfs:label "score" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:float .
+
+ex:active a owl:DatatypeProperty ;
+    rdfs:label "active" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:boolean .
+
+ex:joinedAt a owl:DatatypeProperty ;
+    rdfs:label "joinedAt" ;
+    rdfs:domain ex:Person ;
+    rdfs:range xsd:dateTime .
+"#;
+
+#[test]
+fn datatype_properties_imported_as_add_property() {
+    let (_dir, db) = blank_db();
+    let summary = import_turtle(&db, DATATYPE_TTL, ImportOptions::default()).unwrap();
+
+    assert_eq!(summary.classes_imported, 1, "expected 1 class");
+    assert_eq!(
+        summary.relations_imported, 0,
+        "owl:DatatypeProperty must NOT create relations"
+    );
+    assert_eq!(summary.properties_imported, 5, "expected 5 data properties");
+    assert!(
+        summary.warnings.is_empty(),
+        "unexpected warnings: {:?}",
+        summary.warnings
+    );
+
+    let snap = export_schema(&db).unwrap();
+    let person_props: Vec<_> = snap
+        .properties
+        .iter()
+        .filter(|p| p.owner_name == "Person")
+        .collect();
+
+    assert_eq!(
+        person_props.len(),
+        5,
+        "Person should have 5 properties after import"
+    );
+
+    let names: Vec<&str> = person_props.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"age"), "missing 'age'");
+    assert!(names.contains(&"name"), "missing 'name'");
+    assert!(names.contains(&"score"), "missing 'score'");
+    assert!(names.contains(&"active"), "missing 'active'");
+    assert!(names.contains(&"joinedAt"), "missing 'joinedAt'");
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Test 14 — XSD type mapping: integer→int, float→float, boolean→bool, date→date
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn datatype_xsd_types_map_correctly() {
+    let (_dir, db) = blank_db();
+    import_turtle(&db, DATATYPE_TTL, ImportOptions::default()).unwrap();
+
+    let snap = export_schema(&db).unwrap();
+    let prop = |name: &str| {
+        snap.properties
+            .iter()
+            .find(|p| p.owner_name == "Person" && p.name == name)
+            .unwrap_or_else(|| panic!("property '{}' not found", name))
+            .datatype
+            .clone()
+    };
+
+    assert!(
+        matches!(prop("age"), PropertyType::Int64),
+        "age should be Int64"
+    );
+    assert!(
+        matches!(prop("name"), PropertyType::String),
+        "name should be String"
+    );
+    assert!(
+        matches!(prop("score"), PropertyType::Float64),
+        "score should be Float64"
+    );
+    assert!(
+        matches!(prop("active"), PropertyType::Bool),
+        "active should be Bool"
+    );
+    assert!(
+        matches!(prop("joinedAt"), PropertyType::Date),
+        "joinedAt should be Date"
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Test 15 — DatatypeProperty without domain → warning, not panic
+// ══════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn datatype_property_no_domain_emits_warning() {
+    let (_dir, db) = blank_db();
+    let ttl = r#"
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <https://example.org/> .
+
+ex:orphan a owl:DatatypeProperty ;
+    rdfs:label "orphan" ;
+    rdfs:range xsd:string .
+"#;
+
+    let summary = import_turtle(&db, ttl, ImportOptions::default()).unwrap();
+    assert_eq!(
+        summary.properties_imported, 0,
+        "no-domain property must not be imported"
+    );
+    assert_eq!(
+        summary.warnings.len(),
+        1,
+        "expected exactly one warning for missing domain"
+    );
+    assert!(
+        summary.warnings[0].contains("no rdfs:domain"),
+        "warning must mention missing domain, got: {}",
+        summary.warnings[0]
     );
 }

--- a/tests/tools/verify_rdf.py
+++ b/tests/tools/verify_rdf.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Independent RDF verification for the WS1 instance-data exporter.
+
+This is a **test-only** script. Nothing in the shipped crates depends on it, and
+it adds no runtime dependency — it exists so the Turtle and JSON-LD that
+`sparrowdb-ontology-core` emits are checked by a third-party RDF implementation
+(rdflib) rather than only by the same oxrdf library that produced them.
+
+Usage:
+    verify_rdf.py <export1.ttl> <export2.ttl> <export1.jsonld>
+
+Checks:
+  1. Both Turtle files parse cleanly.
+  2. The JSON-LD parses cleanly through rdflib's JSON-LD 1.1 processor.
+  3. export1 and export2 are graph-isomorphic (the round-trip guarantee).
+  4. The JSON-LD serialization is isomorphic to the Turtle serialization
+     (the two exports describe one graph, not two).
+
+Exits 0 on success, 1 on failure, and 77 (skip) if rdflib is unavailable so the
+Rust harness can distinguish "not checked" from "checked and wrong".
+"""
+
+import sys
+
+try:
+    from rdflib import Graph
+    from rdflib.compare import isomorphic, graph_diff
+except ImportError:
+    print("SKIP: rdflib not installed", file=sys.stderr)
+    sys.exit(77)
+
+
+def load(path, fmt):
+    g = Graph()
+    g.parse(path, format=fmt)
+    return g
+
+
+def report_diff(label, a, b):
+    _, only_a, only_b = graph_diff(a, b)
+    print(f"FAIL: {label} are not isomorphic", file=sys.stderr)
+    for t in sorted(only_a, key=str)[:20]:
+        print(f"  only in first:  {t}", file=sys.stderr)
+    for t in sorted(only_b, key=str)[:20]:
+        print(f"  only in second: {t}", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 1
+    ttl1, ttl2, jsonld1 = sys.argv[1:4]
+
+    g1 = load(ttl1, "turtle")
+    g2 = load(ttl2, "turtle")
+    gj = load(jsonld1, "json-ld")
+
+    print(f"parsed: {ttl1}={len(g1)} triples, {ttl2}={len(g2)} triples, "
+          f"{jsonld1}={len(gj)} triples")
+
+    # The exporter never emits blank nodes (WS1 non-goal), so for these ground
+    # graphs isomorphism coincides with set equality. isomorphic() is used
+    # anyway: it is the check the spec names, and it stays correct if blank
+    # nodes are ever introduced.
+    ok = True
+    if not isomorphic(g1, g2):
+        report_diff("the two Turtle exports", g1, g2)
+        ok = False
+    if not isomorphic(g1, gj):
+        report_diff("Turtle and JSON-LD", g1, gj)
+        ok = False
+
+    if ok:
+        print("OK: exports are graph-isomorphic (Turtle round-trip and JSON-LD)")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `export_data_turtle`, `export_data_json_ld`, and `import_data_turtle` for round-tripping **instance data** (as opposed to schema/ontology) to/from RDF — 3 new MCP tools, 2 new CLI subcommands.
- Handles datatype mapping, IRI minting, dangling-edge detection/reporting, and orphan-property reporting; documented in `docs/rdf-data-export.md`.
- Adds `__so_iri` to validation's provenance allowlist so minted/round-tripped source IRIs pass validation.
- Bumps the SparrowDB git-main patch to the 0.1.25 rev — needed for a duplicate-edge fix `export_data_turtle` depends on. Pinned explicitly rather than tracking `main`'s tip, since `main` has since moved to a stricter `DELETE` that refuses to remove a node with edges attached (`NodeHasEdges`) — a separate behavior change to evaluate on its own, not bundled into this PR.

## Why this targets `fix/issue-39-datatype-property-metadata` instead of `main`
This branch's `validation.rs` change constructs `OntologyProperty` with `description`/`source_iri` fields that only exist once issue #39's changes (PR #40) land. Once #40 merges to `main`, this PR should be retargeted to `main`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all passing (25 new tests in `tests/integration/test_rdf_data.rs`)
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets` — clean
- [x] `tests/tools/verify_rdf.py` — independent rdflib-based cross-check of exported Turtle/JSON-LD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pgmscJMKyJH2EXg8LETNu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RDF instance-data export in Turtle and JSON-LD formats.
  * Added Turtle data import with strict and auto-declare strategies.
  * Added three MCP tools and matching CLI commands for RDF data exchange.
  * Added detailed import/export reports, validation, skip handling, and stable subject IRIs.

* **Documentation**
  * Documented RDF workflows, datatype mappings, import strategies, and MCP usage.
  * Updated the tool count to 22 and workspace test count to 211.

* **Tests**
  * Added comprehensive RDF round-trip, validation, and interoperability coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->