### PR TITLE
ci(rdf): rdflib in CI, --locked, vacuous-counter tests, mcp-reference docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,25 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      # rdflib backs tests/tools/verify_rdf.py, the independent-implementation
+      # cross-check that roundtrip_is_graph_isomorphic runs against the
+      # exporter's own Turtle/JSON-LD output. SPARROW_RDFLIB_REQUIRED below
+      # turns a missing-rdflib skip into a hard failure in this job, so the
+      # check installed here is the one actually enforced, not a decoration.
+      - run: pip install rdflib
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
-      - run: cargo test --workspace
+      # --locked: Cargo.toml pins the SparrowDB engine to an explicit `rev`,
+      # but only Cargo.lock enforces it — `--locked` fails the build instead
+      # of silently re-resolving if the lockfile and manifest ever disagree.
+      - run: cargo test --workspace --locked
+        env:
+          # Locally, a developer without rdflib installed still gets a skip
+          # (see run_rdflib_check in tests/integration/test_rdf_data.rs). In
+          # CI, rdflib is always installed by the step above, so a skip here
+          # means the cross-check silently stopped running — that must fail
+          # loudly rather than report green.
+          SPARROW_RDFLIB_REQUIRED: "1"

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -341,9 +341,14 @@ Export every entity and relationship as Turtle.
   "orphan_labels": [],
   "orphan_relation_types": [],
   "dangling_edges": 0,
+  "unrepresentable_iris": 0,
   "issues": []
 }
 ```
+
+`unrepresentable_iris` counts classes or entities whose name could not form a
+valid IRI (e.g. a class name containing a space) — skipped and named in
+`issues` rather than aborting the export.
 
 Entities that carry a stored IRI from a previous import keep it; the rest are
 minted as `{base_iri}/{ClassName}/{node_id}`. Export is read-only.
@@ -393,3 +398,10 @@ new one.
 Nothing is dropped silently — every skipped subject appears in `skips` with its
 IRI and an actionable reason. Blank nodes are counted and skipped (blank-node
 preservation is out of scope).
+
+**Partial failure:** the tool call's top-level result carries `"isError":
+true` whenever anything was skipped (`entities_skipped + relationships_skipped
++ blank_nodes_skipped > 0`), matching the CLI's `cmd_import_data`, which
+treats any skip as a pipeline-gate failure. A client that checks `isError`
+before parsing `content` — the documented MCP pattern — sees an import that
+skipped everything as a failure, not a clean-looking success.

--- a/docs/rdf-data-export.md
+++ b/docs/rdf-data-export.md
@@ -211,6 +211,11 @@ rdflib is importable. Point `SPARROW_RDFLIB_PYTHON` at an interpreter that has
 rdflib to enable it in CI; without it the script exits 77 and the test reports
 the cross-check as skipped rather than passing silently.
 
+`.github/workflows/ci.yml` installs rdflib and sets `SPARROW_RDFLIB_REQUIRED=1`
+for the test step, so in CI a skip (exit 77, or the interpreter failing to
+launch) fails the build instead of quietly passing — a local run without
+rdflib installed still skips normally.
+
 ## Engine caveats
 
 As of SparrowDB 0.1.27 (the version this crate pins), the engine refuses to

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -502,6 +502,133 @@ fn import_report_surfaces_every_skip_with_its_subject() {
     assert!(r4.contains("rdf:type"), "{r4}");
 }
 
+/// `blank_nodes_skipped` was asserted only as `== 0` on fixtures containing
+/// no blank node anywhere in the suite — deleting the blank-node handling in
+/// `import_data_turtle` would not fail any test. This drives it nonzero.
+///
+/// The fixture has one well-formed named subject and one blank-node subject
+/// carrying two triples (`a` and `name`). Blank-node subjects are counted
+/// **per triple**, not per subject — `import_data_turtle` increments
+/// `blank_nodes_skipped` in the parser loop before any subject is even
+/// assembled — so two triples on `_:b1` means the counter reads 2, not 1.
+#[test]
+fn blank_node_subject_is_counted_and_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    let ttl = format!(
+        r#"
+        <{BASE}/Person/1> a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Valid Person" .
+
+        _:b1 a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Blank Node Person" .
+        "#
+    );
+
+    let report = import_data_turtle(&db, &ttl, ImportStrategy::Strict).unwrap();
+
+    // _:b1's two triples (`a`, `name`) each hit the BlankNode arm before a
+    // SubjectData is ever created for it, so it never becomes an entity skip
+    // and never appears in `skips` (which is keyed by subject IRI — a blank
+    // node has none to record).
+    assert_eq!(report.blank_nodes_skipped, 2, "{report:?}");
+    assert_eq!(report.entities_imported, 1, "{report:?}");
+    assert_eq!(report.entities_skipped, 0, "{report:?}");
+    assert_eq!(report.skips.len(), 0, "{report:?}");
+}
+
+/// `relationships_skipped` was asserted only as `== 0` on a fixture with no
+/// broken relationship anywhere in the suite. This drives it nonzero with a
+/// relationship whose target was never imported as an entity (no `rdf:type`
+/// triple for it at all — it exists only as an object).
+#[test]
+fn relationship_with_missing_endpoint_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    // Person/1 is well-formed and declares one WORKS_FOR edge to
+    // Organization/999 — which never appears as a subject, so it is never
+    // imported and `node_of` has no entry for it.
+    let ttl = format!(
+        r#"
+        <{BASE}/Person/1> a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Ada" ;
+            <{BASE}/schema/WORKS_FOR> <{BASE}/Organization/999> .
+        "#
+    );
+
+    let report = import_data_turtle(&db, &ttl, ImportStrategy::Strict).unwrap();
+
+    // The entity itself imports fine — only the relationship it declares is
+    // rejected, in the second pass over already-imported subjects.
+    assert_eq!(report.entities_imported, 1, "{report:?}");
+    assert_eq!(report.entities_skipped, 0, "{report:?}");
+    assert_eq!(report.relationships_imported, 0, "{report:?}");
+    assert_eq!(report.relationships_skipped, 1, "{report:?}");
+    assert_eq!(report.skips.len(), 1, "{report:?}");
+
+    let skip = &report.skips[0];
+    assert_eq!(skip.subject, format!("{BASE}/Person/1"));
+    assert!(skip.reason.contains("WORKS_FOR"), "{}", skip.reason);
+    assert!(
+        skip.reason.contains(&format!("{BASE}/Organization/999")),
+        "{}",
+        skip.reason
+    );
+}
+
+/// `report.warnings` was referenced nowhere in the suite, so the
+/// language-tag-drop path was entirely unverified. A language-tagged literal
+/// must import — SparrowOntology v1 stores plain strings, so the tag is
+/// dropped and the lexical value kept — and it must warn, not silently lose
+/// information.
+#[test]
+fn language_tagged_literal_is_stored_without_tag_and_warned() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = GraphDb::open(dir.path()).unwrap();
+    declare_schema(&db);
+
+    let ttl = format!(
+        r#"
+        <{BASE}/Person/1> a <{BASE}/schema/Person> ;
+            <{BASE}/schema/name> "Ada"@en .
+        "#
+    );
+
+    let report = import_data_turtle(&db, &ttl, ImportStrategy::Strict).unwrap();
+
+    assert_eq!(report.entities_imported, 1, "{report:?}");
+    assert_eq!(report.entities_skipped, 0, "{report:?}");
+    assert_eq!(
+        report.warnings.len(),
+        1,
+        "expected exactly one language-tag warning: {report:?}"
+    );
+    assert!(
+        report.warnings[0].contains("Language tag"),
+        "{}",
+        report.warnings[0]
+    );
+    assert!(
+        report.warnings[0].contains(&format!("{BASE}/Person/1")),
+        "{}",
+        report.warnings[0]
+    );
+
+    // The tag is dropped, not the value: the literal's lexical form survives
+    // into the stored property, and the entity round-trips through export.
+    db.checkpoint().unwrap();
+    let (ttl2, export_report) = export_data_with_report(&db, BASE).unwrap();
+    assert_eq!(export_report.entities_exported, 1, "{export_report:?}");
+    assert!(
+        ttl2.contains("\"Ada\""),
+        "expected the language-tagged value to survive as a plain string: {ttl2}"
+    );
+}
+
 /// `ImportStrategy::AutoDeclare` declares what `Strict` rejects.
 #[test]
 fn auto_declare_creates_missing_schema() {

--- a/tests/integration/test_rdf_data.rs
+++ b/tests/integration/test_rdf_data.rs
@@ -820,6 +820,15 @@ fn schema_export_json_ld_is_unchanged() {
 /// adds a *second, independent* implementation's opinion, which is what the
 /// spec asks for. If rdflib is not installed the script exits 77 and this is
 /// reported as skipped — never silently treated as a pass.
+/// True when the environment says a skip must be treated as a failure —
+/// set by `.github/workflows/ci.yml`, which installs rdflib before the test
+/// step runs specifically so this check is real there. Unset locally, so a
+/// developer without rdflib still gets a skip rather than a spurious
+/// failure.
+fn rdflib_required() -> bool {
+    std::env::var("SPARROW_RDFLIB_REQUIRED").as_deref() == Ok("1")
+}
+
 fn run_rdflib_check(ttl1: &str, ttl2: &str, jsonld: &serde_json::Value) {
     let dir = tempfile::tempdir().unwrap();
     let p1 = dir.path().join("export1.ttl");
@@ -845,6 +854,11 @@ fn run_rdflib_check(ttl1: &str, ttl2: &str, jsonld: &serde_json::Value) {
     {
         Ok(o) => o,
         Err(e) => {
+            assert!(
+                !rdflib_required(),
+                "rdflib cross-check is REQUIRED (SPARROW_RDFLIB_REQUIRED=1) but {python} \
+                 could not be run: {e}"
+            );
             eprintln!("rdflib cross-check SKIPPED: cannot run {python}: {e}");
             return;
         }
@@ -854,11 +868,23 @@ fn run_rdflib_check(ttl1: &str, ttl2: &str, jsonld: &serde_json::Value) {
     let stderr = String::from_utf8_lossy(&out.stderr);
     match out.status.code() {
         Some(0) => eprintln!("rdflib cross-check PASSED: {}", stdout.trim()),
-        // 77 is the script's "rdflib not installed" signal.
-        Some(77) => eprintln!(
-            "rdflib cross-check SKIPPED: rdflib not installed. \
-             Set SPARROW_RDFLIB_PYTHON to an interpreter that has it."
-        ),
+        // 77 is the script's "rdflib not installed" signal. That is an
+        // acceptable skip on a developer machine, but if the environment
+        // says rdflib is required (CI installs it before this test runs),
+        // exit 77 means the install step failed or the wrong interpreter is
+        // being used — a real problem, not something to skip past quietly.
+        Some(77) => {
+            assert!(
+                !rdflib_required(),
+                "rdflib cross-check is REQUIRED (SPARROW_RDFLIB_REQUIRED=1) but rdflib is not \
+                 importable via {python}. Check the CI install step, or SPARROW_RDFLIB_PYTHON \
+                 if it points at the wrong interpreter."
+            );
+            eprintln!(
+                "rdflib cross-check SKIPPED: rdflib not installed. \
+                 Set SPARROW_RDFLIB_PYTHON to an interpreter that has it."
+            );
+        }
         _ => panic!("rdflib cross-check FAILED:\n{stdout}\n{stderr}"),
     }
 }


### PR DESCRIPTION
## Context

Remainder of the review findings from #43 (feat: instance-data RDF export/import, merged 2026-08-18). #43 had gone through several rounds of CodeRabbit + human review; this PR closes out the infra/docs/test-coverage items that were left explicitly non-blocking at merge time, plus one doc gap found while verifying them.

**Already fixed on `main` as part of #43 — not touched here:**
- SparrowDB pinned to an explicit `rev` (not `branch = "main"`)
- `docs/rdf-data-export.md`'s "Engine caveats" section reframed to describe current (0.1.27) behavior, not the pre-fix bugs
- MCP `import_data_turtle` sets `isError: true` on any skip, matching the CLI's exit-code gate
- Export snapshot isolation (`ReadTx`/`begin_read`) — fixed by a sibling PR also stacked on #43's findings

**What this PR does:**

1. **`.github/workflows/ci.yml`** — installs rdflib via `actions/setup-python`, adds `--locked` to `cargo test --workspace`. The rdflib cross-check (`tests/tools/verify_rdf.py`, run from `roundtrip_is_graph_isomorphic`) previously exited 77 ("not installed") and printed SKIPPED-as-pass in every CI run, since nothing installed it — the strongest correctness evidence in #43 never executed. `--locked` makes the SparrowDB rev pin's guarantee structural: a lockfile/manifest disagreement now fails the build instead of silently re-resolving.

2. **`tests/integration/test_rdf_data.rs`** — `run_rdflib_check` now reads `SPARROW_RDFLIB_REQUIRED` (set by the CI step above): unset (local dev without rdflib) still skips as before; set, the same skip panics. Also adds 3 tests driving previously-vacuous counters nonzero — `blank_nodes_skipped` and `relationships_skipped` were asserted only as `== 0` on fixtures containing neither, and `report.warnings` was referenced nowhere:
   - `blank_node_subject_is_counted_and_skipped`
   - `relationship_with_missing_endpoint_is_skipped`
   - `language_tagged_literal_is_stored_without_tag_and_warned`

   Each was confirmed to fail against the pre-existing code (temporarily removed the relevant counter increment / warning push, ran the specific test, confirmed the panic, reverted with `git checkout --` before moving to the next — no net diff).

3. **`docs/mcp-reference.md`** — documents `import_data_turtle`'s `isError` partial-failure contract (code already did this; the doc never caught up), and adds `unrepresentable_iris` to `export_data_turtle`'s example response (present in `ExportReport` since #43's 75f2559, missing from the doc).

4. **`docs/rdf-data-export.md`** — one paragraph documenting `SPARROW_RDFLIB_REQUIRED` and its CI effect.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --keep-going` — 0 warnings
- [x] `cargo test --workspace --locked` — 217 passed, 0 failed, 0 ignored (19 test binaries)
- [x] `test_rdf_data.rs` alone: 15/15 (12 pre-existing + 3 new)
- [x] `Cargo.lock` unchanged (rev pin was already correct; verified `git diff --stat Cargo.lock` is empty)
- [x] Each new test independently confirmed to fail pre-fix (see commit message for `test(rdf): ...` for the exact panic output quoted per test)
- [ ] CI itself has not yet run on this PR — the rdflib-installed-and-passing path (`Some(0) => PASSED`) was never observed locally (this machine has no rdflib); only the skip→fail wiring was verified locally. Worth confirming the CI job goes green, not just that it fails correctly when it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq3C5J646sBCH7sVs3uaCE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how invalid IRIs are handled during Turtle exports.
  - Documented partial-failure behavior for Turtle imports, including error reporting when data is skipped.

- **Reliability**
  - Expanded RDF integration coverage for blank nodes, missing relationship endpoints, and language-tagged values.
  - Improved validation of skipped data, warnings, counters, and re-export behavior.

- **Quality Assurance**
  - RDF verification now runs as a required check in CI, while remaining optional for local environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->